### PR TITLE
Improve dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,4 @@ yarn test --watchAll
 
 ### MusicXML Examples
 
-In order to add a MusicXML example:
-
-1. Add the xml file to [dev/public/examples](dev/public/examples) directory.
-2. Add the name of the xml file to the [dev/public/manifest.json](dev/public/manifest.json).
+In order to add a MusicXML example, add the xml file to [dev/public/examples](dev/public/examples) directory.

--- a/dev/public/manifest.json
+++ b/dev/public/manifest.json
@@ -1,3 +1,0 @@
-{
-  "examples": ["beam.xml", "simple.xml"]
-}

--- a/dev/src/index.ts
+++ b/dev/src/index.ts
@@ -29,6 +29,7 @@ const render = async (example: string): Promise<void> => {
     vexml.EasyScoreMessageRenderer.render(content.id, xml);
     status.innerHTML = '';
   } catch (e) {
+    status.innerHTML = 'error';
     const pre = document.createElement('pre');
     pre.innerHTML = e instanceof Error ? e.stack || e.message : `something went wrong: ${e}`;
     content.innerHTML = '';
@@ -37,7 +38,7 @@ const render = async (example: string): Promise<void> => {
 };
 
 window.addEventListener('load', async () => {
-  const res = await fetch('manifest.json');
+  const res = await fetch('/manifest');
   const manifest = await res.json();
   manifest.examples.forEach(render);
 });

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
+const fs = require('fs');
+
+const EXAMPLES_DIR = path.join(__dirname, 'public', 'examples');
 
 module.exports = {
   mode: 'development',
@@ -8,6 +11,12 @@ module.exports = {
   devServer: {
     static: path.resolve(__dirname, 'public'),
     hot: true,
+    onAfterSetupMiddleware: (devServer) => {
+      devServer.app.get('/manifest', (req, res) => {
+        const examples = fs.readdirSync(EXAMPLES_DIR);
+        res.json({ examples });
+      });
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
Prior to this PR, a dev would have to add an example file to `dev/public/examples` and add an entry to `dev/public/manifest.json`. This PR adds a `/manifest` endpoint, which dynamically fetches what files are in `dev/public/examples`, which makes it easier to add examples.