### PR TITLE
Add filters to dev app

### DIFF
--- a/dev/src/components/Examples.tsx
+++ b/dev/src/components/Examples.tsx
@@ -1,21 +1,47 @@
-import { Divider, Typography } from 'antd';
-import React, { useCallback, useState } from 'react';
+import { Checkbox, Divider, Typography } from 'antd';
+import { CheckboxValueType } from 'antd/lib/checkbox/Group';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useConstant } from '../hooks/useConstant';
 import { Format, useFetch } from '../hooks/useFetch';
 import { AlphabeticalIndex } from './AlphabeticalIndex';
 import { Example } from './Example';
 import { RenderStatus } from './RenderStatus';
 import { VexmlStatus } from './Vexml';
 
-const ExampleContainer = styled.div`
+const NUM_SLOWEST_VISIBLE = 10;
+
+const ExampleContainer = styled.div<{ visible: boolean }>`
+  display: ${(props) => (props.visible ? 'block' : 'none')};
   padding-bottom: 24px;
+`;
+
+const StyledListItem = styled.li`
+  border-radius: 4px;
+  padding-left: 4px;
+
+  :hover {
+    background-color: #eee;
+  }
 `;
 
 export const Examples: React.FC = () => {
   const result = useFetch('/manifest', Format.Json);
 
   const [statuses, setStatuses] = useState<Record<string, VexmlStatus>>({});
+  const loading = useMemo(() => {
+    switch (result.type) {
+      case 'idle':
+        return true;
+      case 'loading':
+        return true;
+      case 'error':
+        return false;
+      case 'success':
+        return result.data.examples.some((exampleId: string) => !(exampleId in statuses));
+    }
+  }, [statuses, result]);
   const onUpdate = useCallback((state: VexmlStatus) => {
     setStatuses((statuses) => ({ ...statuses, [state.exampleId]: state }));
   }, []);
@@ -35,6 +61,61 @@ export const Examples: React.FC = () => {
     [statuses]
   );
 
+  const [successVisible, setSuccessVisible] = useState(true);
+  const [failVisible, setFailVisible] = useState(true);
+  const [slowestVisible, setSlowestVisible] = useState(false);
+  const options = useMemo(() => {
+    const numSuccess = Object.values(statuses).filter((status) => status.type === 'success').length;
+    const numFailed = Object.values(statuses).filter((status) => status.type === 'error').length;
+    return [
+      {
+        label: `success (${numSuccess})`,
+        value: 'success',
+        disabled: successVisible && successVisible !== failVisible,
+      },
+      {
+        label: `failed (${numFailed})`,
+        value: 'fail',
+        disabled: failVisible && successVisible !== failVisible,
+      },
+      {
+        label: `slowest (${Math.min(Object.keys(statuses).length, NUM_SLOWEST_VISIBLE)})`,
+        value: 'slowest',
+      },
+    ];
+  }, [successVisible, failVisible, statuses]);
+  const defaultFilters = useConstant(() => ['success', 'fail']);
+  const onFiltersChange = useCallback((checkedValues: CheckboxValueType[]): void => {
+    setSuccessVisible(checkedValues.includes('success'));
+    setFailVisible(checkedValues.includes('fail'));
+    setSlowestVisible(checkedValues.includes('slowest'));
+  }, []);
+  const filteredExampleIds = useMemo<string[]>(() => {
+    if (result.type !== 'success') {
+      return [];
+    }
+    const examples: string[] = slowestVisible
+      ? result.data.examples
+          .slice()
+          .sort((a: string, b: string) => {
+            const aStatus = statuses[a];
+            const bStatus = statuses[b];
+            const aMs = aStatus && aStatus.type === 'success' ? aStatus.elapsedMs : Number.NEGATIVE_INFINITY;
+            const bMs = bStatus && bStatus.type === 'success' ? bStatus.elapsedMs : Number.NEGATIVE_INFINITY;
+            return bMs - aMs;
+          })
+          .slice(0, NUM_SLOWEST_VISIBLE)
+      : result.data.examples;
+    return examples.filter(
+      (exampleId) =>
+        typeof statuses[exampleId] === 'undefined' || // it's still loading
+        statuses[exampleId].type === 'rendering' ||
+        (statuses[exampleId].type === 'success' && successVisible) ||
+        (statuses[exampleId].type === 'error' && failVisible)
+    );
+  }, [result, slowestVisible, successVisible, failVisible, statuses]);
+  const filteredExampleIdsSet = useMemo(() => new Set(filteredExampleIds), [filteredExampleIds]);
+
   return (
     <>
       {result.type === 'success' && (
@@ -42,7 +123,27 @@ export const Examples: React.FC = () => {
           <Typography.Title id="index" level={2}>
             index
           </Typography.Title>
-          <AlphabeticalIndex keys={result.data.examples} renderKey={renderExampleStatus} />
+
+          <Typography.Title level={3}>filters</Typography.Title>
+          <Checkbox.Group
+            options={options}
+            defaultValue={defaultFilters}
+            onChange={onFiltersChange}
+            disabled={loading}
+          />
+
+          <br />
+          <br />
+
+          {slowestVisible ? (
+            <ol>
+              {filteredExampleIds.map((exampleId) => (
+                <StyledListItem key={exampleId}>{renderExampleStatus(exampleId)}</StyledListItem>
+              ))}
+            </ol>
+          ) : (
+            <AlphabeticalIndex keys={filteredExampleIds} renderKey={renderExampleStatus} />
+          )}
 
           <Divider />
 
@@ -50,7 +151,7 @@ export const Examples: React.FC = () => {
             examples
           </Typography.Title>
           {result.data.examples.map((exampleId: string) => (
-            <ExampleContainer key={exampleId}>
+            <ExampleContainer key={exampleId} visible={filteredExampleIdsSet.has(exampleId)}>
               <Typography.Title id={exampleId} level={3}>
                 <RenderStatus exampleId={exampleId} status={statuses[exampleId]} />
               </Typography.Title>

--- a/dev/src/components/Examples.tsx
+++ b/dev/src/components/Examples.tsx
@@ -70,8 +70,7 @@ export const Examples: React.FC = () => {
       {
         label: 'success',
         value: 'success',
-        disabled:
-          settings.slowestVisible || (settings.successVisible && settings.successVisible !== settings.failVisible),
+        disabled: settings.successVisible && settings.successVisible !== settings.failVisible,
       },
       {
         label: 'failed',
@@ -113,25 +112,30 @@ export const Examples: React.FC = () => {
     if (result.type !== 'success') {
       return [];
     }
-    const examples: string[] = settings.slowestVisible
-      ? result.data.examples
-          .slice()
-          .sort((a: string, b: string) => {
-            const aStatus = statuses[a];
-            const bStatus = statuses[b];
-            const aMs = aStatus && aStatus.type === 'success' ? aStatus.elapsedMs : Number.NEGATIVE_INFINITY;
-            const bMs = bStatus && bStatus.type === 'success' ? bStatus.elapsedMs : Number.NEGATIVE_INFINITY;
-            return bMs - aMs;
-          })
-          .slice(0, NUM_SLOWEST_VISIBLE)
-      : result.data.examples;
-    return examples.filter(
+    const examples = (result.data.examples as string[]).filter(
       (exampleId) =>
         typeof statuses[exampleId] === 'undefined' || // it's still loading
         statuses[exampleId].type === 'rendering' ||
         (statuses[exampleId].type === 'success' && settings.successVisible) ||
         (statuses[exampleId].type === 'error' && settings.failVisible)
     );
+    return settings.slowestVisible
+      ? examples
+          .sort((a: string, b: string) => {
+            const aStatus = statuses[a];
+            const bStatus = statuses[b];
+            const aMs =
+              (aStatus && aStatus.type === 'success') || (aStatus && aStatus.type === 'error')
+                ? aStatus.elapsedMs
+                : Number.NEGATIVE_INFINITY;
+            const bMs =
+              (bStatus && bStatus.type === 'success') || (bStatus && bStatus.type === 'error')
+                ? bStatus.elapsedMs
+                : Number.NEGATIVE_INFINITY;
+            return bMs - aMs;
+          })
+          .slice(0, NUM_SLOWEST_VISIBLE)
+      : examples;
   }, [result, settings, statuses]);
   const filteredExampleIdsSet = useMemo(() => new Set(filteredExampleIds), [filteredExampleIds]);
 

--- a/dev/src/components/Examples.tsx
+++ b/dev/src/components/Examples.tsx
@@ -80,7 +80,6 @@ export const Examples: React.FC = () => {
       {
         label: 'slowest',
         value: 'slowest',
-        disabled: !settings.successVisible,
       },
     ];
   }, [settings]);

--- a/dev/src/components/RenderStatus.tsx
+++ b/dev/src/components/RenderStatus.tsx
@@ -31,7 +31,7 @@ export const RenderStatus: React.FC<RenderStatusProps> = (props) => {
       <StatusIcon status={state} />
       <Divider type="vertical" />
       {exampleId}
-      {state && state.type === 'success' && (
+      {state && (state.type === 'success' || state.type === 'error') && (
         <>
           <Divider type="vertical" />
           {`(${state.elapsedMs} ms)`}

--- a/dev/src/components/StatusSummary.tsx
+++ b/dev/src/components/StatusSummary.tsx
@@ -1,0 +1,51 @@
+import { Col, Row, Statistic } from 'antd';
+import React, { useMemo } from 'react';
+import { VexmlStatus } from './Vexml';
+
+const BAD_COLOR = '#cf1322';
+const GOOD_COLOR = '#3f8600';
+
+export type StatusSummaryProps = {
+  exampleIds: string[];
+  statuses: Record<string, VexmlStatus>;
+};
+
+export const StatusSummary: React.FC<StatusSummaryProps> = (props) => {
+  const { exampleIds, statuses } = props;
+  const stats = useMemo(
+    () => ({
+      num: exampleIds.length,
+      numSuccess: Object.values(statuses).filter((status) => status.type === 'success').length,
+      numFailed: Object.values(statuses).filter((status) => status.type === 'error').length,
+    }),
+    [exampleIds, statuses]
+  );
+
+  const progress = ((stats.numSuccess + stats.numFailed) / stats.num) * 100;
+  const loading = progress < 100;
+
+  return (
+    <Row gutter={24}>
+      <Col>
+        <Statistic title="total" value={stats.num} />{' '}
+      </Col>
+      <Col>
+        <Statistic title="progress" suffix="%" precision={0} value={progress} />
+      </Col>
+      <Col>
+        <Statistic
+          title="success"
+          value={stats.numSuccess}
+          valueStyle={{ color: loading ? '#000' : stats.numSuccess === 0 ? BAD_COLOR : GOOD_COLOR }}
+        />
+      </Col>
+      <Col>
+        <Statistic
+          title="failed"
+          value={stats.numFailed}
+          valueStyle={{ color: loading ? '#000' : stats.numFailed > 0 ? BAD_COLOR : GOOD_COLOR }}
+        />
+      </Col>
+    </Row>
+  );
+};

--- a/dev/src/components/Vexml.tsx
+++ b/dev/src/components/Vexml.tsx
@@ -15,6 +15,7 @@ export type VexmlStatus =
     }
   | {
       type: 'error';
+      elapsedMs: number;
       exampleId: string;
       error: any;
       codePrinter: vexml.CodePrinter;
@@ -36,7 +37,8 @@ export const Vexml: React.FC<VexmlProps> = (props) => {
   const [status, setStatus] = useState<VexmlStatus>({ type: 'rendering', exampleId });
   const [codePrinter] = useState(() => new vexml.CodePrinter());
   const success = (elapsedMs: number) => setStatus({ type: 'success', exampleId, elapsedMs, codePrinter });
-  const error = (e: any) => setStatus({ type: 'error', exampleId, error: getErrorMessage(e), codePrinter });
+  const error = (e: any, elapsedMs: number) =>
+    setStatus({ type: 'error', exampleId, error: getErrorMessage(e), codePrinter, elapsedMs });
 
   useEffect(() => {
     const start = new Date().getTime();
@@ -45,7 +47,8 @@ export const Vexml: React.FC<VexmlProps> = (props) => {
       const stop = new Date().getTime();
       success(stop - start);
     } catch (e) {
-      error(e);
+      const stop = new Date().getTime();
+      error(e, stop - start);
     }
   }, [id, xml, codePrinter]);
 

--- a/dev/src/hooks/useConstant.ts
+++ b/dev/src/hooks/useConstant.ts
@@ -1,0 +1,7 @@
+import { useMemo } from 'react';
+
+type Factory<T> = () => T;
+
+export const useConstant = <T>(factory: Factory<T>): T => {
+  return useMemo(factory, []);
+};

--- a/dev/src/hooks/useLocalStorage.ts
+++ b/dev/src/hooks/useLocalStorage.ts
@@ -1,0 +1,79 @@
+// from https://github.com/stringsync/stringsync/blob/e0611f57165e72312538f631ee642e7a0e9e268b/web/src/hooks/useLocalStorage.ts
+import { useCallback, useState } from 'react';
+
+type FlatSerializable = {
+  [key: string]: string | number | boolean | null;
+};
+
+const isType = <T extends FlatSerializable>(target: T, obj: any): obj is T => {
+  if (typeof obj !== 'object') {
+    return false;
+  }
+
+  for (const [k, v] of Object.entries(obj)) {
+    if (!(k in target)) {
+      return false;
+    }
+    if (typeof target[k] !== typeof v) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * Merges only the keys that exist in the dst object iff the corresponding value types match. This
+ * excludes any extra keys, but preserves the values in src. This is particularly useful when the
+ * src object schema's change, and you want to make a best effort to keep the compatible key-values
+ * that already exist.
+ */
+const sanitize = <T extends FlatSerializable>(target: T, obj: any) => {
+  const sanitized = { ...target };
+
+  if (typeof obj !== 'object') {
+    return sanitized;
+  }
+
+  for (const [k, v] of Object.entries(target)) {
+    if (!(k in obj)) {
+      continue;
+    }
+    if (typeof obj[k] === typeof v) {
+      (sanitized as FlatSerializable)[k] = obj[k];
+    }
+  }
+
+  return sanitized;
+};
+
+// Adapted from https://usehooks.com/useLocalStorage/
+export const useLocalStorage = <T extends FlatSerializable>(
+  key: string,
+  initialValue: Readonly<T>
+): [T, (value: T) => void] => {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      const parsedValue = item ? JSON.parse(item) : initialValue;
+      return isType(initialValue, parsedValue) ? parsedValue : sanitize(initialValue, parsedValue);
+    } catch (error) {
+      console.error(error);
+      return { ...initialValue };
+    }
+  });
+
+  const setValue = useCallback(
+    (value: T) => {
+      try {
+        setStoredValue(sanitize(initialValue, value));
+        window.localStorage.setItem(key, JSON.stringify(value));
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    [initialValue, key]
+  );
+
+  return [storedValue, setValue];
+};

--- a/dev/src/hooks/useSettings.ts
+++ b/dev/src/hooks/useSettings.ts
@@ -1,0 +1,19 @@
+import { useLocalStorage } from './useLocalStorage';
+
+const SETTINGS_KEY = 'vexml:dev_settings';
+
+export type Settings = {
+  successVisible: boolean;
+  failVisible: boolean;
+  slowestVisible: boolean;
+};
+
+export const DEFAULT_SETTINGS: Settings = Object.freeze({
+  successVisible: true,
+  failVisible: true,
+  slowestVisible: false,
+});
+
+export const useSettings = (): [Settings, (settings: Settings) => void] => {
+  return useLocalStorage(SETTINGS_KEY, DEFAULT_SETTINGS);
+};


### PR DESCRIPTION
The motivation for this PR was to address the poor performance when rendering the index page. This was partly due to the number of renders that the `<AlphabeticalIndex>` component had to do every time a render status changed. Now, the `<AlphabeticalIndex>` component is rendered after all of the examples finish rendering.

- adds `success`, `failed`, and `slowest` filters to the dev app
- adds stats to the dev app
- improves performance on the initial load
- saves settings in `LocalStorage`, so filters persist on hot reload

>NOTE: Toggling the "success" examples is still laggy. I think this is due to 100+ elements being updated at once. I'm not planning to fix this since it's a minor inconvenience.

![image](https://user-images.githubusercontent.com/19232300/163681112-1ed327e8-f163-49b7-8350-ff7cec33880a.png)
