### PR TITLE
Add Copy Code button

### DIFF
--- a/dev/src/components/Example.tsx
+++ b/dev/src/components/Example.tsx
@@ -1,7 +1,8 @@
-import { CameraOutlined } from '@ant-design/icons';
+import { CameraOutlined, CopyOutlined } from '@ant-design/icons';
 import { Alert, Button, message, Tabs, Typography } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import { ExampleStatus, useExampleStatus } from '../hooks/useExampleStatus';
 import { Format, useFetch } from '../hooks/useFetch';
 import { useSnapshot } from '../hooks/useSnapshot';
@@ -12,6 +13,11 @@ import { ExampleTitle } from './ExampleTitle';
 import { Vexml, VexmlStatus } from './Vexml';
 
 const { TabPane } = Tabs;
+
+const CallToActionButton = styled(Button)`
+  margin-right: 8px;
+  margin-bottom: 12px;
+`;
 
 export type ExampleProps = {
   title?: boolean;
@@ -87,6 +93,11 @@ export const Example: React.FC<ExampleProps> = (props) => {
     onUpdate && onUpdate(exampleStatus);
   }, [exampleStatus]);
 
+  const onCopyCodeClick = useCallback(() => {
+    navigator.clipboard.writeText(code);
+    message.success('code copied to clipboard');
+  }, [code]);
+
   return (
     <>
       {title && (
@@ -97,7 +108,7 @@ export const Example: React.FC<ExampleProps> = (props) => {
 
       <br />
 
-      <Button
+      <CallToActionButton
         type="primary"
         icon={<CameraOutlined />}
         onClick={onSnapshotClick}
@@ -105,7 +116,11 @@ export const Example: React.FC<ExampleProps> = (props) => {
         loading={isServerSnapshotLoading}
       >
         snapshot
-      </Button>
+      </CallToActionButton>
+
+      <CallToActionButton icon={<CopyOutlined />} onClick={onCopyCodeClick}>
+        copy code
+      </CallToActionButton>
 
       {result.type === 'success' && (
         <Tabs defaultActiveKey="1">
@@ -131,6 +146,7 @@ export const Example: React.FC<ExampleProps> = (props) => {
           </TabPane>
           <TabPane tab="code" key="4">
             <Typography.Title level={2}>code</Typography.Title>
+            {!code && <Typography.Text type="secondary">none</Typography.Text>}
             {code && <Alert type="info" message={<pre>{code}</pre>} />}
           </TabPane>
           <TabPane tab="source" key="5">

--- a/dev/src/components/Example.tsx
+++ b/dev/src/components/Example.tsx
@@ -118,7 +118,7 @@ export const Example: React.FC<ExampleProps> = (props) => {
         snapshot
       </CallToActionButton>
 
-      <CallToActionButton icon={<CopyOutlined />} onClick={onCopyCodeClick}>
+      <CallToActionButton icon={<CopyOutlined />} disabled={!code} onClick={onCopyCodeClick}>
         copy code
       </CallToActionButton>
 


### PR DESCRIPTION
This PR partially addresses #24. It adds a "copy code" button to each example:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/19232300/165754460-54b97c51-ea9b-414c-b045-4f5cb8f773e3.png">

In a downstream PR, I will either add a lazily loaded embedded jsfiddle with the code prepopulated or a link that opens jsfiddle in a new tab with the code prepopulated.