### PR TITLE
Add resnap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ To bypass Docker, run:
 yarn jest
 ```
 
-This will cause snapshots to be saved to `tests/integration/__tmp_image_snapshots__`, which is ignored by git. **It is important that you run it for the first time on a branch without any changes.** Doing this on a dirty branch could cause you to have an incorrect snapshot, which may cause problems when developing. You can delete the directory at any time, and they'll be regenerated the next time the test suite is run. Alternatively, you can run the following command to update the snapshots on a clean branch:
+This will cause snapshots to be saved to `tests/integration/__tmp_image_snapshots__`, which is ignored by git. **It is important that you run it for the first time on a branch without any changes.** Doing this on a dirty branch could cause you to have an incorrect snapshot, which may cause problems when developing.
+
+If you suspect issues with the tmp snapshots, run the following command to retake the snapshots (which is scripted to do this at origin/master):
 
 ```
 yarn resnap

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ To bypass Docker, run:
 yarn jest
 ```
 
-This will cause snapshots to be saved to `tests/integration/__tmp_image_snapshots__`, which is ignored by git. **It is important that you run it for the first time on a branch without any changes.** Doing this on a dirty branch could cause you to have an incorrect snapshot, which may cause problems when developing. You can delete the directory at any time, and they'll be regenerated the next time the test suite is run.
+This will cause snapshots to be saved to `tests/integration/__tmp_image_snapshots__`, which is ignored by git. **It is important that you run it for the first time on a branch without any changes.** Doing this on a dirty branch could cause you to have an incorrect snapshot, which may cause problems when developing. You can delete the directory at any time, and they'll be regenerated the next time the test suite is run. Alternatively, you can run the following command to update the snapshots on a clean branch:
+
+```
+yarn resnap
+```
 
 ### Snapshots
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "webpack",
     "typecheck": "yarn tsc --noEmit",
     "build:image": "docker build . --tag vexml:latest",
+    "resnap": "rm -rf tests/integration/__tmp_image_snapshots__ && yarn jest integration --silent",
     "lint": "yarn eslint .",
     "format": "yarn prettier .",
     "pretest": "yarn build:image",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "webpack",
     "typecheck": "yarn tsc --noEmit",
     "build:image": "docker build . --tag vexml:latest",
-    "resnap": "rm -rf tests/integration/__tmp_image_snapshots__ && yarn jest integration --silent",
+    "resnap": "node scripts/resnap.js",
     "lint": "yarn eslint .",
     "format": "yarn prettier .",
     "pretest": "yarn build:image",

--- a/scripts/resnap.js
+++ b/scripts/resnap.js
@@ -8,10 +8,14 @@ const rl = readline.createInterface({
 });
 
 try {
-  rl.question(`WARNING: Your staged git changes will become unstaged. Do you want to continue? (y/n): `, (answer) => {
+  const hasChanges = execSync('git status --porcelain').toString().trim().length > 0;
+
+  rl.question(`WARNING: Any staged git changes will become unstaged. Do you want to continue? (y/n): `, (answer) => {
     if (answer === 'y') {
-      console.log('Stashing any pending git changes...');
-      execSync('git stash');
+      if (hasChanges) {
+        console.log('Stashing any pending git changes...');
+        execSync('git stash');
+      }
 
       console.log('Getting current branch...');
       const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
@@ -25,8 +29,10 @@ try {
       console.log(`Checking out ${branch}...`);
       execSync(`git checkout ${branch}`);
 
-      console.log('Unstashing changes...');
-      execSync('git stash pop');
+      if (hasChanges) {
+        console.log('Unstashing changes...');
+        execSync('git stash pop');
+      }
     }
     rl.close();
   });

--- a/scripts/resnap.js
+++ b/scripts/resnap.js
@@ -1,27 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { execSync } = require('child_process');
 
-// Avoid injection attacks via branch names.
-function shellEscape(str) {
-  return `'${str.replace(/'/g, `'\\''`)}'`;
-}
-
 try {
   console.log('Stashing any pending git changes...');
   execSync('git stash');
 
-  const branch = shellEscape(execSync('git rev-parse --abbrev-ref HEAD').toString().trim());
-  console.log(`Current branch: ${branch}`);
+  console.log('Getting current branch...');
+  const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 
+  console.log('Checking out origin/master...');
   execSync('git -c advice.detachedHead=false checkout origin/master');
 
   console.log('Updating snapshots...');
   execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --silent --updateSnapshot');
 
-  console.log(`Checking out ${branch}`);
+  console.log(`Checking out ${branch}...`);
   execSync(`git checkout ${branch}`);
 
-  console.log('Unstashing changes');
+  console.log('Unstashing changes...');
   execSync('git stash pop');
 
   console.log('Done.');

--- a/scripts/resnap.js
+++ b/scripts/resnap.js
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { execSync } = require('child_process');
+
+// Avoid injection attacks via branch names.
+function shellEscape(str) {
+  return `'${str.replace(/'/g, `'\\''`)}'`;
+}
+
+try {
+  console.log('Stashing any pending git changes...');
+  execSync('git stash');
+
+  const branch = shellEscape(execSync('git rev-parse --abbrev-ref HEAD').toString().trim());
+  console.log(`Current branch: ${branch}`);
+
+  execSync('git -c advice.detachedHead=false checkout origin/master');
+
+  console.log('Updating snapshots...');
+  execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --silent --updateSnapshot');
+
+  console.log(`Checking out ${branch}`);
+  execSync(`git checkout ${branch}`);
+
+  console.log('Unstashing changes');
+  execSync('git stash pop');
+
+  console.log('Done.');
+} catch (error) {
+  console.error(`Error executing a command: ${error.message}`);
+}

--- a/scripts/resnap.js
+++ b/scripts/resnap.js
@@ -1,26 +1,35 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { execSync } = require('child_process');
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
 
 try {
-  console.log('Stashing any pending git changes...');
-  execSync('git stash');
+  rl.question(`WARNING: Your staged git changes will become unstaged. Do you want to continue? (y/n): `, (answer) => {
+    if (answer === 'y') {
+      console.log('Stashing any pending git changes...');
+      execSync('git stash');
 
-  console.log('Getting current branch...');
-  const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+      console.log('Getting current branch...');
+      const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
 
-  console.log('Checking out origin/master...');
-  execSync('git -c advice.detachedHead=false checkout origin/master');
+      console.log('Checking out origin/master...');
+      execSync('git -c advice.detachedHead=false checkout origin/master');
 
-  console.log('Updating snapshots...');
-  execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --silent --updateSnapshot');
+      console.log('Updating snapshots...');
+      execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --updateSnapshot > /dev/null');
 
-  console.log(`Checking out ${branch}...`);
-  execSync(`git checkout ${branch}`);
+      console.log(`Checking out ${branch}...`);
+      execSync(`git checkout ${branch}`);
 
-  console.log('Unstashing changes...');
-  execSync('git stash pop');
-
-  console.log('Done.');
+      console.log('Unstashing changes...');
+      execSync('git stash pop');
+    }
+    rl.close();
+  });
 } catch (error) {
   console.error(`Error executing a command: ${error.message}`);
 }

--- a/scripts/resnap.js
+++ b/scripts/resnap.js
@@ -24,7 +24,7 @@ try {
       execSync('git -c advice.detachedHead=false checkout origin/master');
 
       console.log('Updating snapshots...');
-      execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --updateSnapshot > /dev/null');
+      execSync('JEST_IMAGE_SNAPSHOT_TRACK_OBSOLETE=1 yarn jest integration --updateSnapshot --silent');
 
       console.log(`Checking out ${branch}...`);
       execSync(`git checkout ${branch}`);

--- a/tests/unit/musicxml/note.test.ts
+++ b/tests/unit/musicxml/note.test.ts
@@ -477,8 +477,9 @@ describe(Note, () => {
       const note2 = xml.note();
       const note3 = xml.note({ chord: xml.chord() });
       const note4 = xml.note({ chord: xml.chord() });
+      const note5 = xml.note();
 
-      xml.measure({ notes: [note1, note2, note3, note4] });
+      xml.measure({ notes: [note1, note2, note3, note4, note5] });
 
       expect(new Note(note2).getChordTail()).toStrictEqual([new Note(note3), new Note(note4)]);
     });


### PR DESCRIPTION
This PR adds the `yarn resnap` command, which scripts out switching to a clean branch, then updating the tmp snapshots. This particularly improves the DX running tests outside of Docker.