### PR TITLE
Add debug command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,9 +2,9 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Attach to Process",
       "type": "node",
       "request": "attach",
-      "name": "Attach",
       "port": 9229
     }
   ]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To run a debugger, run:
 yarn debug
 ```
 
-If you're using VSCode, open the debugging tool and launch `Attach`. You can set breakpoints in VSCode or insert `debugger` statements to cause execution to pause.
+If you're using VSCode, open the debugging tool and launch `Attach to Process`. You can set breakpoints in VSCode or insert `debugger` statements to cause execution to pause.
 
 If you're not using VSCode, open Chrome and visit chrome://inspect. You should see a virtual device that starts with `./node_modules/.bin/jest` with an "inspect" button. Clicking this will allow you to use the Chrome debugger.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ If you suspect issues with the tmp snapshots, run the following command to retak
 yarn resnap
 ```
 
+### Debugging Tests
+
+To run a debugger, run:
+
+```
+yarn debug
+```
+
+If you're using VSCode, open the debugging tool and launch `Attach`. You can set breakpoints in VSCode or insert `debugger` statements to cause execution to pause.
+
+If you're not using VSCode, open Chrome and visit chrome://inspect. You should see a virtual device that starts with `./node_modules/.bin/jest` with an "inspect" button. Clicking this will allow you to use the Chrome debugger.
+
+If you're still having issues, check the jest [docs](https://jestjs.io/docs/troubleshooting) or file an issue.
+
 ### Snapshots
 
 This library uses [americanexpress/jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot) for image-based snapshot tests.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "yarn tsc --noEmit",
     "build:image": "docker build . --tag vexml:latest",
     "resnap": "node scripts/resnap.js",
+    "debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand",
     "lint": "yarn eslint .",
     "format": "yarn prettier .",
     "pretest": "yarn build:image",

--- a/src/rendering/stave.ts
+++ b/src/rendering/stave.ts
@@ -242,7 +242,6 @@ export class Stave {
 
         const vfTickables = vfVoices.flatMap((vfVoice) => vfVoice.getTickables());
         if (vfTickables.length > 0) {
-          // TODO: Use Formatter.format instead of Formatter.formatToStave so we have more control over rendering.
           new vexflow.Formatter().joinVoices(vfVoices).formatToStave(vfVoices, vfStave);
         }
         break;


### PR DESCRIPTION
This PR adds `yarn debug` command which facilitates debugging using VSCode or a node process inspector.

The branch was named "format" because I wanted to explore simplifying [these methods](https://github.com/stringsync/vexml/blob/0e09bb854ccacdbeafb0902ac8e7eb5e8a13a8c6/src/rendering/stave.ts#L264-L297), but I ran into some issues. I'll work more with @rvilarl how to do this without rendering the vexflow Staves.