### PR TITLE
Fix docker-based test running #123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ ENV VEXML_CANONICAL_TEST_ENV=true
 
 WORKDIR /vexml
 
+# Elevate temporarily to perform setup
+# See https://github.com/puppeteer/puppeteer/blob/163394d7353d755e2b5ec47ffe56e2e869214860/docker/Dockerfile#L16
+USER root
+RUN chown -R pptruser:pptruser /vexml \
+    && chmod -R ugoa+rwX /vexml
+USER pptruser
+
 # Install dependencies.
 COPY package.json .
 COPY yarn.lock .

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "yarn build:image",
     "pretest:ci": "yarn build:image",
     "pretest:m1": "yarn build:image:m1",
-    "test": "docker run -it --rm -v ./src:/vexml/src -v ./tests:/vexml/tests vexml:latest yarn jest --runInBand",
+    "test": "docker run -it --rm -v src:/vexml/src -v tests:/vexml/tests vexml:latest yarn jest --runInBand",
     "test:ci": "docker run --rm vexml:latest yarn jest --runInBand --ci"
   },
   "dependencies": {


### PR DESCRIPTION
- Fix permissions of `/vexml` folder tree to allow installing packages and writing files
- Fix `package.json` `test` script for volume-mounting syntax that is compatible with Linux
