### PR TITLE
Migrate staff* references to stave*

### DIFF
--- a/src/musicxml/attributes.ts
+++ b/src/musicxml/attributes.ts
@@ -2,7 +2,7 @@ import { Clef } from './clef';
 import { Key } from './key';
 import { NamedElement } from '@/util';
 import { Time } from './time';
-import { StaffDetails } from './staffdetails';
+import { StaveDetails } from './stavedetails';
 import { MeasureStyle } from './measurestyle';
 
 /**
@@ -20,8 +20,8 @@ export class Attributes {
   }
 
   /** Returns the staff details. */
-  getStaffDetails(): StaffDetails[] {
-    return this.element.all('staff-details').map((element) => new StaffDetails(element));
+  getStaffDetails(): StaveDetails[] {
+    return this.element.all('staff-details').map((element) => new StaveDetails(element));
   }
 
   /** Returns the times. */

--- a/src/musicxml/attributes.ts
+++ b/src/musicxml/attributes.ts
@@ -19,8 +19,8 @@ export class Attributes {
     return this.element.first('staves')?.content().withDefault(1).int() ?? 1;
   }
 
-  /** Returns the staff details. */
-  getStaffDetails(): StaveDetails[] {
+  /** Returns the stave details. */
+  getStaveDetails(): StaveDetails[] {
     return this.element.all('staff-details').map((element) => new StaveDetails(element));
   }
 

--- a/src/musicxml/clef.ts
+++ b/src/musicxml/clef.ts
@@ -2,15 +2,15 @@ import { ClefAnnotation, ClefSign, ClefType, CLEF_SIGNS } from './enums';
 import { NamedElement } from '@/util';
 
 /**
- * A symbol placed at the left-hand end of  staff, indicating the pitch of the notes written.
+ * A symbol placed at the left-hand end of the stave, indicating the pitch of the notes written.
  *
  * See https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/clef-sign/
  */
 export class Clef {
   constructor(private element: NamedElement<'clef'>) {}
 
-  /** Returns the staff number this clef belongs to. */
-  getStaffNumber(): number {
+  /** Returns the stave number this clef belongs to. */
+  getStaveNumber(): number {
     return this.element.attr('number').withDefault(1).int();
   }
 

--- a/src/musicxml/defaults.ts
+++ b/src/musicxml/defaults.ts
@@ -1,14 +1,14 @@
 import { NamedElement } from '@/util';
-import { StaffLayout, SystemLayout } from './types';
+import { StaveLayout, SystemLayout } from './types';
 
 export class Defaults {
   constructor(private element: NamedElement<'defaults'>) {}
 
-  /** Returns staff layouts of the defaults element. */
-  getStaffLayouts(): StaffLayout[] {
+  /** Returns stave layouts of the defaults element. */
+  getStaveLayouts(): StaveLayout[] {
     return this.element.all('staff-layout').map((element) => ({
-      staffNumber: element.attr('number').withDefault(1).int(),
-      staffDistance: element.first('staff-distance')?.content().withDefault(0).int() ?? null,
+      staveNumber: element.attr('number').withDefault(1).int(),
+      staveDistance: element.first('staff-distance')?.content().withDefault(0).int() ?? null,
     }));
   }
 

--- a/src/musicxml/enums.ts
+++ b/src/musicxml/enums.ts
@@ -254,12 +254,12 @@ export type BeamValue = EnumValues<typeof BEAM_VALUES>;
 export const BEAM_VALUES = new Enum(['backward hook', 'begin', 'continue', 'end', 'forward hook'] as const);
 
 /**
- * The staff-type value specifies different uses for the staff.
+ * The stave-type value specifies different uses for the staff.
  *
  * See https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/staff-type/
  */
-export type StaffType = EnumValues<typeof STAFF_TYPES>;
-export const STAFF_TYPES = new Enum(['alternate', 'cue', 'editorial', 'ossia', 'regular'] as const);
+export type StaveType = EnumValues<typeof STAVE_TYPES>;
+export const STAVE_TYPES = new Enum(['alternate', 'cue', 'editorial', 'ossia', 'regular'] as const);
 
 /**
  * Lyric hyphenation is indicated by the syllabic type.

--- a/src/musicxml/enums.ts
+++ b/src/musicxml/enums.ts
@@ -254,7 +254,7 @@ export type BeamValue = EnumValues<typeof BEAM_VALUES>;
 export const BEAM_VALUES = new Enum(['backward hook', 'begin', 'continue', 'end', 'forward hook'] as const);
 
 /**
- * The stave-type value specifies different uses for the staff.
+ * The stave-type value specifies different uses for the stave.
  *
  * See https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/staff-type/
  */

--- a/src/musicxml/index.ts
+++ b/src/musicxml/index.ts
@@ -14,7 +14,7 @@ export * from './scorepartwise';
 export * from './time';
 export * from './timesignature';
 export * from './types';
-export * from './staffdetails';
+export * from './stavedetails';
 export * from './defaults';
 export * from './lyric';
 export * from './measurestyle';

--- a/src/musicxml/key.ts
+++ b/src/musicxml/key.ts
@@ -13,8 +13,8 @@ export class Key {
     return this.element.first('fifths')?.content().int() ?? 0;
   }
 
-  /** Returns the staff number this key belongs to. */
-  getStaffNumber(): number {
+  /** Returns the stave number this key belongs to. */
+  getStaveNumber(): number {
     return this.element.attr('number').withDefault(1).int();
   }
 

--- a/src/musicxml/measurestyle.ts
+++ b/src/musicxml/measurestyle.ts
@@ -8,8 +8,8 @@ import { NamedElement } from '@/util';
 export class MeasureStyle {
   constructor(private element: NamedElement<'measure-style'>) {}
 
-  /** Returns the staff number this measure style belongs to. */
-  getStaffNumber(): number {
+  /** Returns the stave number this measure style belongs to. */
+  getStaveNumber(): number {
     return this.element.attr('number').withDefault(1).int();
   }
 

--- a/src/musicxml/note.ts
+++ b/src/musicxml/note.ts
@@ -67,8 +67,8 @@ export class Note {
     return this.element.first('voice')?.content().str() ?? '1';
   }
 
-  /** Returns the staff the note belongs to. */
-  getStaffNumber(): number {
+  /** Returns the stave the note belongs to. */
+  getStaveNumber(): number {
     return this.element.first('staff')?.content().int() ?? 1;
   }
 

--- a/src/musicxml/print.ts
+++ b/src/musicxml/print.ts
@@ -1,5 +1,5 @@
 import { NamedElement } from '@/util';
-import { StaffLayout, SystemLayout } from './types';
+import { StaveLayout, SystemLayout } from './types';
 
 /**
  * Contains general printing parameters, including layout elements.
@@ -10,7 +10,7 @@ export class Print {
   constructor(private element: NamedElement<'print'>) {}
 
   /** Returns staff layouts of the print. */
-  getStaffLayouts(): StaffLayout[] {
+  getStaffLayouts(): StaveLayout[] {
     return this.element.all('staff-layout').map((element) => ({
       staffNumber: element.attr('number').withDefault(1).int(),
       staffDistance: element.first('staff-distance')?.content().withDefault(0).int() ?? null,

--- a/src/musicxml/print.ts
+++ b/src/musicxml/print.ts
@@ -9,11 +9,11 @@ import { StaveLayout, SystemLayout } from './types';
 export class Print {
   constructor(private element: NamedElement<'print'>) {}
 
-  /** Returns staff layouts of the print. */
-  getStaffLayouts(): StaveLayout[] {
+  /** Returns stave layouts of the print. */
+  getStaveLayouts(): StaveLayout[] {
     return this.element.all('staff-layout').map((element) => ({
-      staffNumber: element.attr('number').withDefault(1).int(),
-      staffDistance: element.first('staff-distance')?.content().withDefault(0).int() ?? null,
+      staveNumber: element.attr('number').withDefault(1).int(),
+      staveDistance: element.first('staff-distance')?.content().withDefault(0).int() ?? null,
     }));
   }
 

--- a/src/musicxml/stavedetails.ts
+++ b/src/musicxml/stavedetails.ts
@@ -2,12 +2,12 @@ import { NamedElement } from '@/util';
 import { STAFF_TYPES, StaffType } from './enums';
 
 /**
- * Indicates different staff (aka stave) types. A stave is the set of five horizontal lines where notes and other musical
+ * Indicates different stave types. A stave is the set of five horizontal lines where notes and other musical
  * symbols are placed.
  *
  * https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/staff-details/
  */
-export class StaffDetails {
+export class StaveDetails {
   constructor(private element: NamedElement<'staff-details'>) {}
 
   /** Returns the staff type. */

--- a/src/musicxml/stavedetails.ts
+++ b/src/musicxml/stavedetails.ts
@@ -1,5 +1,5 @@
 import { NamedElement } from '@/util';
-import { STAFF_TYPES, StaffType } from './enums';
+import { STAVE_TYPES, StaveType } from './enums';
 
 /**
  * Indicates different stave types. A stave is the set of five horizontal lines where notes and other musical
@@ -11,8 +11,8 @@ export class StaveDetails {
   constructor(private element: NamedElement<'staff-details'>) {}
 
   /** Returns the staff type. */
-  getStaffType(): StaffType {
-    return this.element.first('staff-type')?.content().enum(STAFF_TYPES) ?? 'regular';
+  getStaveType(): StaveType {
+    return this.element.first('staff-type')?.content().enum(STAVE_TYPES) ?? 'regular';
   }
 
   /** Returns the number of the staff. */

--- a/src/musicxml/stavedetails.ts
+++ b/src/musicxml/stavedetails.ts
@@ -10,18 +10,18 @@ import { STAVE_TYPES, StaveType } from './enums';
 export class StaveDetails {
   constructor(private element: NamedElement<'staff-details'>) {}
 
-  /** Returns the staff type. */
+  /** Returns the stave type. */
   getStaveType(): StaveType {
     return this.element.first('staff-type')?.content().enum(STAVE_TYPES) ?? 'regular';
   }
 
-  /** Returns the number of the staff. */
-  getStaffNumber(): number {
+  /** Returns the number of the stave. */
+  getStaveNumber(): number {
     return this.element.attr('number').withDefault(1).int();
   }
 
-  /** Returns the number of lines of the staff. */
-  getStaffLines(): number {
+  /** Returns the number of lines of the stave. */
+  getStaveLines(): number {
     return this.element.first('staff-lines')?.content().withDefault(5).int() ?? 5;
   }
 }

--- a/src/musicxml/time.ts
+++ b/src/musicxml/time.ts
@@ -9,8 +9,8 @@ import { TimeSignature } from './timesignature';
 export class Time {
   constructor(private element: NamedElement<'time'>) {}
 
-  /** Returns the staff number this time belongs to. */
-  getStaffNumber(): number {
+  /** Returns the stave number this time belongs to. */
+  getStaveNumber(): number {
     return this.element.attr('number').withDefault(1).int();
   }
 

--- a/src/musicxml/types.ts
+++ b/src/musicxml/types.ts
@@ -1,11 +1,11 @@
 /**
- * StaffLayout describes how a staff is positioned.
+ * StaveLayout describes how a stave is positioned.
  *
  * See https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/staff-layout/
  */
-export type StaffLayout = {
-  staffNumber: number;
-  staffDistance: number | null;
+export type StaveLayout = {
+  staveNumber: number;
+  staveDistance: number | null;
 };
 
 /**

--- a/src/rendering/README.md
+++ b/src/rendering/README.md
@@ -89,7 +89,7 @@ The `vexflow` key serves as a namespace:
 /** The result of rendering a Stave. */
 export type StaveRendering = {
   type: 'stave';
-  staffNumber: number;
+  staveNumber: number;
   width: number;
   vexflow: {
     stave: vexflow.Stave;

--- a/src/rendering/chorus.ts
+++ b/src/rendering/chorus.ts
@@ -178,7 +178,7 @@ export class Chorus {
     if (this.voices.length > 0) {
       const vfVoices = this.voices.map((voice) => voice.render().vexflow.voice);
       const vfFormatter = new vexflow.Formatter();
-      return vfFormatter.joinVoices(vfVoices).preCalculateMinTotalWidth(vfVoices) + this.config.voicePadding;
+      return vfFormatter.joinVoices(vfVoices).preCalculateMinTotalWidth(vfVoices) + this.config.VOICE_PADDING;
     }
     return 0;
   }

--- a/src/rendering/config.ts
+++ b/src/rendering/config.ts
@@ -1,21 +1,21 @@
 export type Config = {
-  defaultSystemDistance: number;
-  defaultStaveDistance: number;
-  titleTopPadding: number;
-  titleFontFamily: string;
-  titleFontSize: string;
-  voicePadding: number;
-  measureNumberFontSize: string;
-  multiMeasureRestWidth: number;
+  DEFAULT_SYSTEM_DISTANCE: number;
+  DEFAULT_STAVE_DISTANCE: number;
+  TITLE_TOP_PADDING: number;
+  TITLE_FONT_FAMILY: string;
+  TITLE_FONT_SIZE: string;
+  VOICE_PADDING: number;
+  MEASURE_NUMBER_FONT_SIZE: string;
+  MULTI_MEASURE_REST_WIDTH: number;
 };
 
 export const DEFAULT_CONFIG: Config = {
-  defaultSystemDistance: 80,
-  defaultStaveDistance: 80,
-  titleTopPadding: 40,
-  titleFontFamily: 'Arial',
-  titleFontSize: '36px',
-  voicePadding: 80,
-  measureNumberFontSize: '10px',
-  multiMeasureRestWidth: 200,
+  DEFAULT_SYSTEM_DISTANCE: 80,
+  DEFAULT_STAVE_DISTANCE: 80,
+  TITLE_TOP_PADDING: 40,
+  TITLE_FONT_FAMILY: 'Arial',
+  TITLE_FONT_SIZE: '36px',
+  VOICE_PADDING: 80,
+  MEASURE_NUMBER_FONT_SIZE: '10px',
+  MULTI_MEASURE_REST_WIDTH: 200,
 } as const;

--- a/src/rendering/config.ts
+++ b/src/rendering/config.ts
@@ -1,6 +1,6 @@
 export type Config = {
   defaultSystemDistance: number;
-  defaultStaffDistance: number;
+  defaultStaveDistance: number;
   titleTopPadding: number;
   titleFontFamily: string;
   titleFontSize: string;
@@ -11,7 +11,7 @@ export type Config = {
 
 export const DEFAULT_CONFIG: Config = {
   defaultSystemDistance: 80,
-  defaultStaffDistance: 80,
+  defaultStaveDistance: 80,
   titleTopPadding: 40,
   titleFontFamily: 'Arial',
   titleFontSize: '36px',

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -180,12 +180,12 @@ export class Measure {
 
     // Check to see if the time signature changed in a manner that requires a separate stave.
     const times1 = attributes1.getTimes().reduce<Record<number, string>>((memo, time) => {
-      memo[time.getStaffNumber()] = util.first(time.getTimeSignatures())?.toString() ?? '';
+      memo[time.getStaveNumber()] = util.first(time.getTimeSignatures())?.toString() ?? '';
       return memo;
     }, {});
 
     for (const time2 of attributes2.getTimes()) {
-      const staffNumber = time2.getStaffNumber();
+      const staffNumber = time2.getStaveNumber();
       const timeSignature1 = times1[staffNumber];
       const timeSignature2 = util.first(time2.getTimeSignatures())?.toString();
 

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -235,7 +235,7 @@ export class Measure {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     previousMeasure: Measure | null;
-    staffLayouts: musicxml.StaffLayout[];
+    staffLayouts: musicxml.StaveLayout[];
   }): MeasureRendering {
     const fragmentRenderings = new Array<MeasureFragmentRendering>();
 

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -169,8 +169,8 @@ export class Measure {
     }, {});
 
     for (const key2 of attributes2.getKeys()) {
-      const staffNumber = key2.getStaveNumber();
-      const keySignature1 = keys1[staffNumber];
+      const staveNumber = key2.getStaveNumber();
+      const keySignature1 = keys1[staveNumber];
       const keySignature2 = key2.getKeySignature();
 
       if (keySignature1 && keySignature1 !== keySignature2) {
@@ -185,8 +185,8 @@ export class Measure {
     }, {});
 
     for (const time2 of attributes2.getTimes()) {
-      const staffNumber = time2.getStaveNumber();
-      const timeSignature1 = times1[staffNumber];
+      const staveNumber = time2.getStaveNumber();
+      const timeSignature1 = times1[staveNumber];
       const timeSignature2 = util.first(time2.getTimeSignatures())?.toString();
 
       if (timeSignature1 && timeSignature1 !== timeSignature2) {
@@ -235,7 +235,7 @@ export class Measure {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     previousMeasure: Measure | null;
-    staffLayouts: musicxml.StaveLayout[];
+    staveLayouts: musicxml.StaveLayout[];
   }): MeasureRendering {
     const fragmentRenderings = new Array<MeasureFragmentRendering>();
 
@@ -251,7 +251,7 @@ export class Measure {
         minRequiredSystemWidth: opts.minRequiredSystemWidth,
         targetSystemWidth: opts.targetSystemWidth,
         previousMeasureFragment: previousFragment,
-        staffLayouts: opts.staffLayouts,
+        staveLayouts: opts.staveLayouts,
       });
       fragmentRenderings.push(fragmentRendering);
 

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -286,7 +286,7 @@ export class Measure {
       x: opts.x + MEASURE_LABEL_OFFSET_X,
       y: opts.y + MEASURE_LABEL_OFFSET_Y,
       color: MEASURE_LABEL_COLOR,
-      size: this.config.measureNumberFontSize,
+      size: this.config.MEASURE_NUMBER_FONT_SIZE,
     });
 
     return {

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -164,12 +164,12 @@ export class Measure {
 
     // Check to see if the key signature changed in a manner that requires a separate stave.
     const keys1 = attributes1.getKeys().reduce<Record<number, string>>((memo, key) => {
-      memo[key.getStaffNumber()] = key.getKeySignature();
+      memo[key.getStaveNumber()] = key.getKeySignature();
       return memo;
     }, {});
 
     for (const key2 of attributes2.getKeys()) {
-      const staffNumber = key2.getStaffNumber();
+      const staffNumber = key2.getStaveNumber();
       const keySignature1 = keys1[staffNumber];
       const keySignature2 = key2.getKeySignature();
 

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -100,7 +100,7 @@ export class MeasureFragment {
         endBarStyle,
         measureEntries: measureEntries.filter((entry) => {
           if (entry instanceof musicxml.Note) {
-            return entry.getStaffNumber() === staffNumber;
+            return entry.getStaveNumber() === staffNumber;
           }
           return true;
         }),

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -83,7 +83,7 @@ export class MeasureFragment {
       const multiRestCount =
         attributes
           ?.getMeasureStyles()
-          .find((measureStyle) => measureStyle.getStaffNumber() === staffNumber)
+          .find((measureStyle) => measureStyle.getStaveNumber() === staffNumber)
           ?.getMultipleRestCount() ?? 0;
 
       const quarterNoteDivisions = attributes?.getQuarterNoteDivisions() ?? 2;

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -77,7 +77,7 @@ export class MeasureFragment {
       const keySignature =
         attributes
           ?.getKeys()
-          .find((key) => key.getStaffNumber() === staffNumber)
+          .find((key) => key.getStaveNumber() === staffNumber)
           ?.getKeySignature() ?? null;
 
       const multiRestCount =

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -148,7 +148,7 @@ export class MeasureFragment {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     previousMeasureFragment: MeasureFragment | null;
-    staffLayouts: musicxml.StaffLayout[];
+    staffLayouts: musicxml.StaveLayout[];
   }): MeasureFragmentRendering {
     const staveRenderings = new Array<StaveRendering>();
 
@@ -174,8 +174,8 @@ export class MeasureFragment {
       staveRenderings.push(staveRendering);
 
       const staffDistance =
-        opts.staffLayouts.find((staffLayout) => staffLayout.staffNumber === staveRendering.staffNumber)
-          ?.staffDistance ?? this.config.defaultStaffDistance;
+        opts.staffLayouts.find((staffLayout) => staffLayout.staveNumber === staveRendering.staffNumber)
+          ?.staveDistance ?? this.config.defaultStaffDistance;
 
       y += staffDistance;
     }

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -175,7 +175,7 @@ export class MeasureFragment {
 
       const staffDistance =
         opts.staffLayouts.find((staffLayout) => staffLayout.staveNumber === staveRendering.staffNumber)
-          ?.staveDistance ?? this.config.defaultStaffDistance;
+          ?.staveDistance ?? this.config.defaultStaveDistance;
 
       y += staffDistance;
     }

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -55,9 +55,9 @@ export class MeasureFragment {
     const previousFragment = opts.previousFragment;
 
     const staves = new Array<Stave>(staveCount);
-    for (let staffNumber = 1; staffNumber <= staveCount; staffNumber++) {
-      const staffIndex = staffNumber - 1;
-      const previousStave = previousFragment?.staves[staffIndex] ?? null;
+    for (let staveNumber = 1; staveNumber <= staveCount; staveNumber++) {
+      const staveIndex = staveNumber - 1;
+      const previousStave = previousFragment?.staves[staveIndex] ?? null;
 
       // Assume that the measureEntries after the attributes do not need a new stave. See how MeasureFragments are
       // constructured in Measure.
@@ -65,42 +65,42 @@ export class MeasureFragment {
       const clefType =
         attributes
           ?.getClefs()
-          .find((clef) => clef.getStaveNumber() === staffNumber)
+          .find((clef) => clef.getStaveNumber() === staveNumber)
           ?.getClefType() ?? null;
 
       const timeSignature =
         attributes
           ?.getTimes()
-          .find((time) => time.getStaveNumber() === staffNumber)
+          .find((time) => time.getStaveNumber() === staveNumber)
           ?.getTimeSignatures()[0] ?? null;
 
       const keySignature =
         attributes
           ?.getKeys()
-          .find((key) => key.getStaveNumber() === staffNumber)
+          .find((key) => key.getStaveNumber() === staveNumber)
           ?.getKeySignature() ?? null;
 
       const multiRestCount =
         attributes
           ?.getMeasureStyles()
-          .find((measureStyle) => measureStyle.getStaveNumber() === staffNumber)
+          .find((measureStyle) => measureStyle.getStaveNumber() === staveNumber)
           ?.getMultipleRestCount() ?? 0;
 
       const quarterNoteDivisions = attributes?.getQuarterNoteDivisions() ?? 2;
 
-      staves[staffIndex] = Stave.create({
+      staves[staveIndex] = Stave.create({
         config,
         clefType,
         timeSignature,
         keySignature,
         multiRestCount,
         quarterNoteDivisions,
-        staffNumber,
+        staveNumber,
         beginningBarStyle,
         endBarStyle,
         measureEntries: measureEntries.filter((entry) => {
           if (entry instanceof musicxml.Note) {
-            return entry.getStaveNumber() === staffNumber;
+            return entry.getStaveNumber() === staveNumber;
           }
           return true;
         }),
@@ -148,7 +148,7 @@ export class MeasureFragment {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     previousMeasureFragment: MeasureFragment | null;
-    staffLayouts: musicxml.StaveLayout[];
+    staveLayouts: musicxml.StaveLayout[];
   }): MeasureFragmentRendering {
     const staveRenderings = new Array<StaveRendering>();
 
@@ -173,11 +173,11 @@ export class MeasureFragment {
       });
       staveRenderings.push(staveRendering);
 
-      const staffDistance =
-        opts.staffLayouts.find((staffLayout) => staffLayout.staveNumber === staveRendering.staffNumber)
+      const staveDistance =
+        opts.staveLayouts.find((staveLayout) => staveLayout.staveNumber === staveRendering.staveNumber)
           ?.staveDistance ?? this.config.defaultStaveDistance;
 
-      y += staffDistance;
+      y += staveDistance;
     }
 
     return {

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -175,7 +175,7 @@ export class MeasureFragment {
 
       const staveDistance =
         opts.staveLayouts.find((staveLayout) => staveLayout.staveNumber === staveRendering.staveNumber)
-          ?.staveDistance ?? this.config.defaultStaveDistance;
+          ?.staveDistance ?? this.config.DEFAULT_STAVE_DISTANCE;
 
       y += staveDistance;
     }

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -71,7 +71,7 @@ export class MeasureFragment {
       const timeSignature =
         attributes
           ?.getTimes()
-          .find((time) => time.getStaffNumber() === staffNumber)
+          .find((time) => time.getStaveNumber() === staffNumber)
           ?.getTimeSignatures()[0] ?? null;
 
       const keySignature =

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -65,7 +65,7 @@ export class MeasureFragment {
       const clefType =
         attributes
           ?.getClefs()
-          .find((clef) => clef.getStaffNumber() === staffNumber)
+          .find((clef) => clef.getStaveNumber() === staffNumber)
           ?.getClefType() ?? null;
 
       const timeSignature =

--- a/src/rendering/part.ts
+++ b/src/rendering/part.ts
@@ -138,7 +138,7 @@ export class Part {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     isLastSystem: boolean;
-    staffLayouts: musicxml.StaffLayout[];
+    staffLayouts: musicxml.StaveLayout[];
   }): PartRendering {
     const measureRenderings = new Array<MeasureRendering>();
 

--- a/src/rendering/part.ts
+++ b/src/rendering/part.ts
@@ -138,7 +138,7 @@ export class Part {
     targetSystemWidth: number;
     minRequiredSystemWidth: number;
     isLastSystem: boolean;
-    staffLayouts: musicxml.StaveLayout[];
+    staveLayouts: musicxml.StaveLayout[];
   }): PartRendering {
     const measureRenderings = new Array<MeasureRendering>();
 
@@ -164,7 +164,7 @@ export class Part {
         previousMeasure,
         minRequiredSystemWidth: opts.minRequiredSystemWidth,
         targetSystemWidth: opts.targetSystemWidth,
-        staffLayouts: opts.staffLayouts,
+        staveLayouts: opts.staveLayouts,
       });
       measureRenderings.push(measureRendering);
 

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -24,14 +24,14 @@ export type ScoreRendering = {
 export class Score {
   private config: Config;
   private system: System;
-  private staffLayouts: musicxml.StaffLayout[];
+  private staffLayouts: musicxml.StaveLayout[];
   private systemLayout: musicxml.SystemLayout | null;
   private title: Title;
 
   private constructor(opts: {
     config: Config;
     system: System;
-    staffLayouts: musicxml.StaffLayout[];
+    staffLayouts: musicxml.StaveLayout[];
     systemLayout: musicxml.SystemLayout | null;
     title: Title;
   }) {
@@ -48,7 +48,7 @@ export class Score {
     const scorePartwise = opts.musicXml.getScorePartwise();
     const parts = scorePartwise?.getParts() ?? [];
     const defaults = scorePartwise?.getDefaults() ?? null;
-    const staffLayouts = defaults?.getStaffLayouts() ?? [];
+    const staffLayouts = defaults?.getStaveLayouts() ?? [];
     const systemLayout = defaults?.getSystemLayout() ?? null;
 
     const title = Title.create({ config, text: scorePartwise?.getTitle() ?? '' });

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -24,20 +24,20 @@ export type ScoreRendering = {
 export class Score {
   private config: Config;
   private system: System;
-  private staffLayouts: musicxml.StaveLayout[];
+  private staveLayouts: musicxml.StaveLayout[];
   private systemLayout: musicxml.SystemLayout | null;
   private title: Title;
 
   private constructor(opts: {
     config: Config;
     system: System;
-    staffLayouts: musicxml.StaveLayout[];
+    staveLayouts: musicxml.StaveLayout[];
     systemLayout: musicxml.SystemLayout | null;
     title: Title;
   }) {
     this.config = opts.config;
     this.system = opts.system;
-    this.staffLayouts = opts.staffLayouts;
+    this.staveLayouts = opts.staveLayouts;
     this.systemLayout = opts.systemLayout;
     this.title = opts.title;
   }
@@ -48,13 +48,13 @@ export class Score {
     const scorePartwise = opts.musicXml.getScorePartwise();
     const parts = scorePartwise?.getParts() ?? [];
     const defaults = scorePartwise?.getDefaults() ?? null;
-    const staffLayouts = defaults?.getStaveLayouts() ?? [];
+    const staveLayouts = defaults?.getStaveLayouts() ?? [];
     const systemLayout = defaults?.getSystemLayout() ?? null;
 
     const title = Title.create({ config, text: scorePartwise?.getTitle() ?? '' });
     const system = System.create({ config, musicXml: { parts } });
 
-    return new Score({ system, staffLayouts, systemLayout, config, title });
+    return new Score({ system, staveLayouts, systemLayout, config, title });
   }
 
   /** Renders the Score. */
@@ -87,7 +87,7 @@ export class Score {
         y,
         width: opts.width - END_BARLINE_OFFSET,
         isLastSystem: index === systems.length - 1,
-        staffLayouts: this.staffLayouts,
+        staveLayouts: this.staveLayouts,
       });
       systemRenderings.push(systemRendering);
 

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -70,7 +70,7 @@ export class Score {
     // Produce the title rendering, but only if it has text.
     let titleRendering: TitleRendering | null = null;
     if (this.title.hasText()) {
-      y += this.config.titleTopPadding;
+      y += this.config.TITLE_TOP_PADDING;
 
       titleRendering = this.title.render({ y, containerWidth: opts.width });
 
@@ -107,7 +107,7 @@ export class Score {
       const height = maxY - y;
 
       y += height;
-      y += this.systemLayout?.systemDistance ?? this.config.defaultSystemDistance;
+      y += this.systemLayout?.systemDistance ?? this.config.DEFAULT_SYSTEM_DISTANCE;
     }
 
     const parts = systemRenderings.flatMap((system) => system.parts);

--- a/src/rendering/stave.ts
+++ b/src/rendering/stave.ts
@@ -120,7 +120,7 @@ export class Stave {
       // This is much easier being configurable. Otherwise, we would have to create a dummy context to render it, then
       // get the width via MultiMeasureRest.getBoundingBox. There is no "preCalculateMinTotalWidth" for non-voices at
       // the moment.
-      return this.config.multiMeasureRestWidth;
+      return this.config.MULTI_MEASURE_REST_WIDTH;
     }
 
     if (this.entry instanceof Chorus) {

--- a/src/rendering/stave.ts
+++ b/src/rendering/stave.ts
@@ -13,7 +13,7 @@ export type StaveEntryRendering = ChorusRendering | MultiRestRendering;
 /** The result of rendering a Stave. */
 export type StaveRendering = {
   type: 'stave';
-  staffNumber: number;
+  staveNumber: number;
   width: number;
   vexflow: {
     stave: vexflow.Stave;
@@ -31,11 +31,11 @@ export type StaveModifier = 'clefType' | 'keySignature' | 'timeSignature';
  * notes, rests, clefs, and key signatures.
  *
  * The `Stave` class acts as a container for musical elements that are vertically aligned in a score or sheet music. It
- * typically corresponds to a specific voice or set of voices, especially in multi-staff instruments like the piano.
+ * typically corresponds to a specific voice or set of voices, especially in multi-stave instruments like the piano.
  */
 export class Stave {
   private config: Config;
-  private staffNumber: number;
+  private staveNumber: number;
   private clefType: musicxml.ClefType;
   private timeSignature: musicxml.TimeSignature;
   private keySignature: string;
@@ -45,7 +45,7 @@ export class Stave {
 
   private constructor(opts: {
     config: Config;
-    staffNumber: number;
+    staveNumber: number;
     clefType: musicxml.ClefType;
     timeSignature: musicxml.TimeSignature;
     keySignature: string;
@@ -54,7 +54,7 @@ export class Stave {
     entry: StaveEntry;
   }) {
     this.config = opts.config;
-    this.staffNumber = opts.staffNumber;
+    this.staveNumber = opts.staveNumber;
     this.timeSignature = opts.timeSignature;
     this.keySignature = opts.keySignature;
     this.beginningBarStyle = opts.beginningBarStyle;
@@ -66,7 +66,7 @@ export class Stave {
   /** Creates a Stave. */
   static create(opts: {
     config: Config;
-    staffNumber: number;
+    staveNumber: number;
     clefType: musicxml.ClefType | null;
     timeSignature: musicxml.TimeSignature | null;
     keySignature: string | null;
@@ -78,7 +78,7 @@ export class Stave {
     endBarStyle: musicxml.BarStyle;
   }): Stave {
     const config = opts.config;
-    const staffNumber = opts.staffNumber;
+    const staveNumber = opts.staveNumber;
     const measureEntries = opts.measureEntries;
     const multiRestCount = opts.multiRestCount;
     const quarterNoteDivisions = opts.quarterNoteDivisions;
@@ -103,7 +103,7 @@ export class Stave {
 
     return new Stave({
       config,
-      staffNumber,
+      staveNumber,
       clefType,
       timeSignature,
       keySignature,
@@ -156,7 +156,7 @@ export class Stave {
   clone(): Stave {
     return new Stave({
       config: this.config,
-      staffNumber: this.staffNumber,
+      staveNumber: this.staveNumber,
       clefType: this.clefType,
       timeSignature: this.timeSignature.clone(),
       keySignature: this.keySignature,
@@ -213,7 +213,7 @@ export class Stave {
 
     return {
       type: 'stave',
-      staffNumber: this.staffNumber,
+      staveNumber: this.staveNumber,
       width: opts.width,
       vexflow: {
         stave: vfStave,

--- a/src/rendering/system.ts
+++ b/src/rendering/system.ts
@@ -111,7 +111,7 @@ export class System {
     y: number;
     width: number;
     isLastSystem: boolean;
-    staffLayouts: musicxml.StaffLayout[];
+    staffLayouts: musicxml.StaveLayout[];
   }): SystemRendering {
     const minRequiredSystemWidth = this.getMinRequiredWidth();
 

--- a/src/rendering/system.ts
+++ b/src/rendering/system.ts
@@ -111,7 +111,7 @@ export class System {
     y: number;
     width: number;
     isLastSystem: boolean;
-    staffLayouts: musicxml.StaveLayout[];
+    staveLayouts: musicxml.StaveLayout[];
   }): SystemRendering {
     const minRequiredSystemWidth = this.getMinRequiredWidth();
 
@@ -122,7 +122,7 @@ export class System {
         isLastSystem: opts.isLastSystem,
         minRequiredSystemWidth,
         targetSystemWidth: opts.width,
-        staffLayouts: opts.staffLayouts,
+        staveLayouts: opts.staveLayouts,
       })
     );
 

--- a/src/rendering/title.ts
+++ b/src/rendering/title.ts
@@ -30,7 +30,7 @@ export class Title {
     const config = opts.config;
     const text = opts.text;
 
-    context.font = `${config.titleFontSize} ${config.titleFontFamily}`;
+    context.font = `${config.TITLE_FONT_SIZE} ${config.TITLE_FONT_FAMILY}`;
 
     const textMetrics = context.measureText(text);
     const width = textMetrics.width;
@@ -49,8 +49,8 @@ export class Title {
     const x = (opts.containerWidth - this.width) / 2;
     const y = opts.y;
     const content = this.text;
-    const size = this.config.titleFontSize;
-    const family = this.config.titleFontFamily;
+    const size = this.config.TITLE_FONT_SIZE;
+    const family = this.config.TITLE_FONT_FAMILY;
 
     const text = new Text({ content, x, y, size, family });
 

--- a/tests/unit/musicxml/attributes.test.ts
+++ b/tests/unit/musicxml/attributes.test.ts
@@ -80,8 +80,8 @@ describe(Attributes, () => {
     });
   });
 
-  describe('getStaffDetails', () => {
-    it('returns the staff details', () => {
+  describe('getStaveDetails', () => {
+    it('returns the stave details', () => {
       const staffDetails1 = xml.staffDetails();
       const staffDetails2 = xml.staffDetails();
       const node = xml.attributes({ staffDetails: [staffDetails1, staffDetails2] });

--- a/tests/unit/musicxml/attributes.test.ts
+++ b/tests/unit/musicxml/attributes.test.ts
@@ -88,7 +88,7 @@ describe(Attributes, () => {
 
       const attributes = new Attributes(node);
 
-      expect(attributes.getStaffDetails()).toStrictEqual([
+      expect(attributes.getStaveDetails()).toStrictEqual([
         new StaveDetails(staffDetails1),
         new StaveDetails(staffDetails2),
       ]);
@@ -97,7 +97,7 @@ describe(Attributes, () => {
     it('returns an empty array when staff details are missing', () => {
       const node = xml.attributes({});
       const attributes = new Attributes(node);
-      expect(attributes.getStaffDetails()).toBeEmpty();
+      expect(attributes.getStaveDetails()).toBeEmpty();
     });
   });
 

--- a/tests/unit/musicxml/attributes.test.ts
+++ b/tests/unit/musicxml/attributes.test.ts
@@ -2,7 +2,7 @@ import { Attributes } from '@/musicxml/attributes';
 import { Clef } from '@/musicxml/clef';
 import { Key } from '@/musicxml/key';
 import { Time } from '@/musicxml/time';
-import { StaffDetails } from '@/musicxml/staffdetails';
+import { StaveDetails } from '@/musicxml/stavedetails';
 import { xml } from '@/util';
 import { MeasureStyle } from '@/musicxml/measurestyle';
 
@@ -89,8 +89,8 @@ describe(Attributes, () => {
       const attributes = new Attributes(node);
 
       expect(attributes.getStaffDetails()).toStrictEqual([
-        new StaffDetails(staffDetails1),
-        new StaffDetails(staffDetails2),
+        new StaveDetails(staffDetails1),
+        new StaveDetails(staffDetails2),
       ]);
     });
 

--- a/tests/unit/musicxml/clef.test.ts
+++ b/tests/unit/musicxml/clef.test.ts
@@ -6,19 +6,19 @@ describe(Clef, () => {
     it('returns the staff number', () => {
       const node = xml.clef({ number: 2 });
       const clef = new Clef(node);
-      expect(clef.getStaffNumber()).toBe(2);
+      expect(clef.getStaveNumber()).toBe(2);
     });
 
     it(`defaults to '1' when invalid staff number`, () => {
       const node = xml.clef({ number: NaN });
       const clef = new Clef(node);
-      expect(clef.getStaffNumber()).toBe(1);
+      expect(clef.getStaveNumber()).toBe(1);
     });
 
     it(`defaults to '1' when staff number missing`, () => {
       const node = xml.clef({});
       const clef = new Clef(node);
-      expect(clef.getStaffNumber()).toBe(1);
+      expect(clef.getStaveNumber()).toBe(1);
     });
   });
 

--- a/tests/unit/musicxml/clef.test.ts
+++ b/tests/unit/musicxml/clef.test.ts
@@ -2,20 +2,20 @@ import { Clef } from '@/musicxml/clef';
 import { xml } from '@/util';
 
 describe(Clef, () => {
-  describe('getStaffNumber', () => {
-    it('returns the staff number', () => {
+  describe('getStaveNumber', () => {
+    it('returns the stave number', () => {
       const node = xml.clef({ number: 2 });
       const clef = new Clef(node);
       expect(clef.getStaveNumber()).toBe(2);
     });
 
-    it(`defaults to '1' when invalid staff number`, () => {
+    it(`defaults to '1' when invalid stave number`, () => {
       const node = xml.clef({ number: NaN });
       const clef = new Clef(node);
       expect(clef.getStaveNumber()).toBe(1);
     });
 
-    it(`defaults to '1' when staff number missing`, () => {
+    it(`defaults to '1' when stave number missing`, () => {
       const node = xml.clef({});
       const clef = new Clef(node);
       expect(clef.getStaveNumber()).toBe(1);

--- a/tests/unit/musicxml/defaults.test.ts
+++ b/tests/unit/musicxml/defaults.test.ts
@@ -2,8 +2,8 @@ import { Defaults } from '@/musicxml';
 import { xml } from '@/util';
 
 describe(Defaults, () => {
-  describe('getStaffLayouts', () => {
-    it('returns staff layouts', () => {
+  describe('getStaveLayouts', () => {
+    it('returns stave layouts', () => {
       const node = xml.defaults({
         staffLayouts: [
           xml.staffLayout({ number: 1, staffDistance: xml.staffDistance({ value: '42' }) }),
@@ -13,9 +13,9 @@ describe(Defaults, () => {
 
       const defaults = new Defaults(node);
 
-      expect(defaults.getStaffLayouts()).toStrictEqual([
-        { staffNumber: 1, staffDistance: 42 },
-        { staffNumber: 2, staffDistance: 43 },
+      expect(defaults.getStaveLayouts()).toStrictEqual([
+        { staveNumber: 1, staveDistance: 42 },
+        { staveNumber: 2, staveDistance: 43 },
       ]);
     });
 
@@ -24,7 +24,7 @@ describe(Defaults, () => {
         staffLayouts: [xml.staffLayout({ staffDistance: xml.staffDistance({ value: '42' }) })],
       });
       const defaults = new Defaults(node);
-      expect(defaults.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: 42 }]);
+      expect(defaults.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: 42 }]);
     });
 
     it('defaults number to 1 when invalid', () => {
@@ -32,7 +32,7 @@ describe(Defaults, () => {
         staffLayouts: [xml.staffLayout({ number: NaN })],
       });
       const defaults = new Defaults(node);
-      expect(defaults.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: null }]);
+      expect(defaults.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: null }]);
     });
 
     it('defaults staff distance to null when missing', () => {
@@ -40,7 +40,7 @@ describe(Defaults, () => {
         staffLayouts: [xml.staffLayout({ number: 1 })],
       });
       const defaults = new Defaults(node);
-      expect(defaults.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: null }]);
+      expect(defaults.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: null }]);
     });
 
     it('defaults staff distance to 0 when invalid', () => {
@@ -48,7 +48,7 @@ describe(Defaults, () => {
         staffLayouts: [xml.staffLayout({ number: 1, staffDistance: xml.staffDistance({ value: 'NaN' }) })],
       });
       const defaults = new Defaults(node);
-      expect(defaults.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: 0 }]);
+      expect(defaults.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: 0 }]);
     });
   });
 

--- a/tests/unit/musicxml/measurestyle.test.ts
+++ b/tests/unit/musicxml/measurestyle.test.ts
@@ -6,19 +6,19 @@ describe(MeasureStyle, () => {
     it('returns the number of the measure style', () => {
       const node = xml.measureStyle({ staffNumber: 4 });
       const measureStyle = new MeasureStyle(node);
-      expect(measureStyle.getStaffNumber()).toBe(4);
+      expect(measureStyle.getStaveNumber()).toBe(4);
     });
 
     it('defaults to 1 when number is missing', () => {
       const node = xml.measureStyle();
       const measureStyle = new MeasureStyle(node);
-      expect(measureStyle.getStaffNumber()).toBe(1);
+      expect(measureStyle.getStaveNumber()).toBe(1);
     });
 
     it('defaults to 1 when number is invalid', () => {
       const node = xml.measureStyle({ staffNumber: NaN });
       const measureStyle = new MeasureStyle(node);
-      expect(measureStyle.getStaffNumber()).toBe(1);
+      expect(measureStyle.getStaveNumber()).toBe(1);
     });
   });
 

--- a/tests/unit/musicxml/measurestyle.test.ts
+++ b/tests/unit/musicxml/measurestyle.test.ts
@@ -2,7 +2,7 @@ import { MeasureStyle } from '@/musicxml';
 import { xml } from '@/util';
 
 describe(MeasureStyle, () => {
-  describe('getStaffNumber', () => {
+  describe('getStaveNumber', () => {
     it('returns the number of the measure style', () => {
       const node = xml.measureStyle({ staffNumber: 4 });
       const measureStyle = new MeasureStyle(node);

--- a/tests/unit/musicxml/note.test.ts
+++ b/tests/unit/musicxml/note.test.ts
@@ -134,19 +134,19 @@ describe(Note, () => {
     it('returns the staff number the note belongs to', () => {
       const node = xml.note({ staff: xml.staff({ number: 42 }) });
       const note = new Note(node);
-      expect(note.getStaffNumber()).toBe(42);
+      expect(note.getStaveNumber()).toBe(42);
     });
 
     it('defaults to 1 when staff number is invalid', () => {
       const node = xml.note({ staff: xml.staff({ number: NaN }) });
       const note = new Note(node);
-      expect(note.getStaffNumber()).toBe(1);
+      expect(note.getStaveNumber()).toBe(1);
     });
 
     it('defaults to 1 when staff number is missing', () => {
       const node = xml.note();
       const note = new Note(node);
-      expect(note.getStaffNumber()).toBe(1);
+      expect(note.getStaveNumber()).toBe(1);
     });
   });
 

--- a/tests/unit/musicxml/note.test.ts
+++ b/tests/unit/musicxml/note.test.ts
@@ -130,20 +130,20 @@ describe(Note, () => {
     });
   });
 
-  describe('getStaffNumber', () => {
-    it('returns the staff number the note belongs to', () => {
+  describe('getStaveNumber', () => {
+    it('returns the stave number the note belongs to', () => {
       const node = xml.note({ staff: xml.staff({ number: 42 }) });
       const note = new Note(node);
       expect(note.getStaveNumber()).toBe(42);
     });
 
-    it('defaults to 1 when staff number is invalid', () => {
+    it('defaults to 1 when stave number is invalid', () => {
       const node = xml.note({ staff: xml.staff({ number: NaN }) });
       const note = new Note(node);
       expect(note.getStaveNumber()).toBe(1);
     });
 
-    it('defaults to 1 when staff number is missing', () => {
+    it('defaults to 1 when stave number is missing', () => {
       const node = xml.note();
       const note = new Note(node);
       expect(note.getStaveNumber()).toBe(1);

--- a/tests/unit/musicxml/print.test.ts
+++ b/tests/unit/musicxml/print.test.ts
@@ -13,9 +13,9 @@ describe(Print, () => {
 
       const print = new Print(node);
 
-      expect(print.getStaffLayouts()).toStrictEqual([
-        { staffNumber: 1, staffDistance: 42 },
-        { staffNumber: 2, staffDistance: 43 },
+      expect(print.getStaveLayouts()).toStrictEqual([
+        { staveNumber: 1, staveDistance: 42 },
+        { staveNumber: 2, staveDistance: 43 },
       ]);
     });
 
@@ -24,7 +24,7 @@ describe(Print, () => {
         staffLayouts: [xml.staffLayout({ staffDistance: xml.staffDistance({ value: '42' }) })],
       });
       const print = new Print(node);
-      expect(print.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: 42 }]);
+      expect(print.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: 42 }]);
     });
 
     it('defaults number to 1 when invalid', () => {
@@ -32,7 +32,7 @@ describe(Print, () => {
         staffLayouts: [xml.staffLayout({ number: NaN })],
       });
       const print = new Print(node);
-      expect(print.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: null }]);
+      expect(print.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: null }]);
     });
 
     it('defaults staff distance to null when missing', () => {
@@ -40,7 +40,7 @@ describe(Print, () => {
         staffLayouts: [xml.staffLayout({ number: 1 })],
       });
       const print = new Print(node);
-      expect(print.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: null }]);
+      expect(print.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: null }]);
     });
 
     it('defaults staff distance to 0 when invalid', () => {
@@ -48,7 +48,7 @@ describe(Print, () => {
         staffLayouts: [xml.staffLayout({ number: 1, staffDistance: xml.staffDistance({ value: 'NaN' }) })],
       });
       const print = new Print(node);
-      expect(print.getStaffLayouts()).toStrictEqual([{ staffNumber: 1, staffDistance: 0 }]);
+      expect(print.getStaveLayouts()).toStrictEqual([{ staveNumber: 1, staveDistance: 0 }]);
     });
   });
 

--- a/tests/unit/musicxml/print.test.ts
+++ b/tests/unit/musicxml/print.test.ts
@@ -2,8 +2,8 @@ import { Print } from '@/musicxml/print';
 import { xml } from '@/util';
 
 describe(Print, () => {
-  describe('getStaffLayouts', () => {
-    it('returns staff layouts', () => {
+  describe('getStaveLayouts', () => {
+    it('returns stave layouts', () => {
       const node = xml.print({
         staffLayouts: [
           xml.staffLayout({ number: 1, staffDistance: xml.staffDistance({ value: '42' }) }),

--- a/tests/unit/musicxml/staffdetails.test.ts
+++ b/tests/unit/musicxml/staffdetails.test.ts
@@ -1,13 +1,13 @@
-import { STAFF_TYPES, StaffDetails } from '@/musicxml';
+import { STAFF_TYPES, StaveDetails } from '@/musicxml';
 import { xml } from '@/util';
 
-describe(StaffDetails, () => {
+describe(StaveDetails, () => {
   describe('getStaffType', () => {
     it.each(STAFF_TYPES.values)('returns the staff type: %s', (value) => {
       const staffType = xml.staffType({ value });
       const node = xml.staffDetails({ staffType });
 
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
 
       expect(staffDetails.getStaffType()).toBe(value);
     });
@@ -16,14 +16,14 @@ describe(StaffDetails, () => {
       const staffType = xml.staffType({ value: 'invalid staff type' });
       const node = xml.staffDetails({ staffType });
 
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
 
       expect(staffDetails.getStaffType()).toBe('regular');
     });
 
     it('returns regular for missing staff types', () => {
       const node = xml.staffDetails({});
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
       expect(staffDetails.getStaffType()).toBe('regular');
     });
   });
@@ -32,19 +32,19 @@ describe(StaffDetails, () => {
     describe('getStaffNumber', () => {
       it('returns the staff number', () => {
         const node = xml.staffDetails({ number: 2 });
-        const staffDetails = new StaffDetails(node);
+        const staffDetails = new StaveDetails(node);
         expect(staffDetails.getStaffNumber()).toBe(2);
       });
 
       it(`defaults to '1' when invalid staff number`, () => {
         const node = xml.staffDetails({ number: NaN });
-        const staffDetails = new StaffDetails(node);
+        const staffDetails = new StaveDetails(node);
         expect(staffDetails.getStaffNumber()).toBe(1);
       });
 
       it(`defaults to '1' when staff number missing`, () => {
         const node = xml.staffDetails({});
-        const staffDetails = new StaffDetails(node);
+        const staffDetails = new StaveDetails(node);
         expect(staffDetails.getStaffNumber()).toBe(1);
       });
     });
@@ -55,14 +55,14 @@ describe(StaffDetails, () => {
       const staffLines = xml.staffLines({ value: 6 });
       const node = xml.staffDetails({ staffLines });
 
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
 
       expect(staffDetails.getStaffLines()).toBe(6);
     });
 
     it('defaults to 5 when missing', () => {
       const node = xml.staffDetails({});
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
       expect(staffDetails.getStaffLines()).toBe(5);
     });
 
@@ -70,7 +70,7 @@ describe(StaffDetails, () => {
       const staffLines = xml.staffLines({ value: NaN });
       const node = xml.staffDetails({ staffLines });
 
-      const staffDetails = new StaffDetails(node);
+      const staffDetails = new StaveDetails(node);
 
       expect(staffDetails.getStaffLines()).toBe(5);
     });

--- a/tests/unit/musicxml/staffdetails.test.ts
+++ b/tests/unit/musicxml/staffdetails.test.ts
@@ -1,15 +1,15 @@
-import { STAFF_TYPES, StaveDetails } from '@/musicxml';
+import { STAVE_TYPES, StaveDetails } from '@/musicxml';
 import { xml } from '@/util';
 
 describe(StaveDetails, () => {
   describe('getStaffType', () => {
-    it.each(STAFF_TYPES.values)('returns the staff type: %s', (value) => {
+    it.each(STAVE_TYPES.values)('returns the staff type: %s', (value) => {
       const staffType = xml.staffType({ value });
       const node = xml.staffDetails({ staffType });
 
       const staffDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaffType()).toBe(value);
+      expect(staffDetails.getStaveType()).toBe(value);
     });
 
     it('returns regular for invalid staff types', () => {
@@ -18,13 +18,13 @@ describe(StaveDetails, () => {
 
       const staffDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaffType()).toBe('regular');
+      expect(staffDetails.getStaveType()).toBe('regular');
     });
 
     it('returns regular for missing staff types', () => {
       const node = xml.staffDetails({});
       const staffDetails = new StaveDetails(node);
-      expect(staffDetails.getStaffType()).toBe('regular');
+      expect(staffDetails.getStaveType()).toBe('regular');
     });
   });
 

--- a/tests/unit/musicxml/staffdetails.test.ts
+++ b/tests/unit/musicxml/staffdetails.test.ts
@@ -33,19 +33,19 @@ describe(StaveDetails, () => {
       it('returns the staff number', () => {
         const node = xml.staffDetails({ number: 2 });
         const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaffNumber()).toBe(2);
+        expect(staffDetails.getStaveNumber()).toBe(2);
       });
 
       it(`defaults to '1' when invalid staff number`, () => {
         const node = xml.staffDetails({ number: NaN });
         const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaffNumber()).toBe(1);
+        expect(staffDetails.getStaveNumber()).toBe(1);
       });
 
       it(`defaults to '1' when staff number missing`, () => {
         const node = xml.staffDetails({});
         const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaffNumber()).toBe(1);
+        expect(staffDetails.getStaveNumber()).toBe(1);
       });
     });
   });
@@ -57,13 +57,13 @@ describe(StaveDetails, () => {
 
       const staffDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaffLines()).toBe(6);
+      expect(staffDetails.getStaveLines()).toBe(6);
     });
 
     it('defaults to 5 when missing', () => {
       const node = xml.staffDetails({});
       const staffDetails = new StaveDetails(node);
-      expect(staffDetails.getStaffLines()).toBe(5);
+      expect(staffDetails.getStaveLines()).toBe(5);
     });
 
     it('defaults to 5 when invalid', () => {
@@ -72,7 +72,7 @@ describe(StaveDetails, () => {
 
       const staffDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaffLines()).toBe(5);
+      expect(staffDetails.getStaveLines()).toBe(5);
     });
   });
 });

--- a/tests/unit/musicxml/staffdetails.test.ts
+++ b/tests/unit/musicxml/staffdetails.test.ts
@@ -2,77 +2,75 @@ import { STAVE_TYPES, StaveDetails } from '@/musicxml';
 import { xml } from '@/util';
 
 describe(StaveDetails, () => {
-  describe('getStaffType', () => {
+  describe('getStaveType', () => {
     it.each(STAVE_TYPES.values)('returns the staff type: %s', (value) => {
       const staffType = xml.staffType({ value });
       const node = xml.staffDetails({ staffType });
 
-      const staffDetails = new StaveDetails(node);
+      const staveDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaveType()).toBe(value);
+      expect(staveDetails.getStaveType()).toBe(value);
     });
 
     it('returns regular for invalid staff types', () => {
       const staffType = xml.staffType({ value: 'invalid staff type' });
       const node = xml.staffDetails({ staffType });
 
-      const staffDetails = new StaveDetails(node);
+      const staveDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaveType()).toBe('regular');
+      expect(staveDetails.getStaveType()).toBe('regular');
     });
 
     it('returns regular for missing staff types', () => {
       const node = xml.staffDetails({});
-      const staffDetails = new StaveDetails(node);
-      expect(staffDetails.getStaveType()).toBe('regular');
+      const staveDetails = new StaveDetails(node);
+      expect(staveDetails.getStaveType()).toBe('regular');
     });
   });
 
-  describe('getStaffNumber', () => {
-    describe('getStaffNumber', () => {
-      it('returns the staff number', () => {
-        const node = xml.staffDetails({ number: 2 });
-        const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaveNumber()).toBe(2);
-      });
+  describe('getStaveNumber', () => {
+    it('returns the staff number', () => {
+      const node = xml.staffDetails({ number: 2 });
+      const staveDetails = new StaveDetails(node);
+      expect(staveDetails.getStaveNumber()).toBe(2);
+    });
 
-      it(`defaults to '1' when invalid staff number`, () => {
-        const node = xml.staffDetails({ number: NaN });
-        const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaveNumber()).toBe(1);
-      });
+    it(`defaults to '1' when invalid staff number`, () => {
+      const node = xml.staffDetails({ number: NaN });
+      const staveDetails = new StaveDetails(node);
+      expect(staveDetails.getStaveNumber()).toBe(1);
+    });
 
-      it(`defaults to '1' when staff number missing`, () => {
-        const node = xml.staffDetails({});
-        const staffDetails = new StaveDetails(node);
-        expect(staffDetails.getStaveNumber()).toBe(1);
-      });
+    it(`defaults to '1' when staff number missing`, () => {
+      const node = xml.staffDetails({});
+      const staveDetails = new StaveDetails(node);
+      expect(staveDetails.getStaveNumber()).toBe(1);
     });
   });
 
-  describe('getStaffLines', () => {
+  describe('getStaveLines', () => {
     it('returns the number of staff lines', () => {
       const staffLines = xml.staffLines({ value: 6 });
       const node = xml.staffDetails({ staffLines });
 
-      const staffDetails = new StaveDetails(node);
+      const staveDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaveLines()).toBe(6);
+      expect(staveDetails.getStaveLines()).toBe(6);
     });
 
     it('defaults to 5 when missing', () => {
       const node = xml.staffDetails({});
-      const staffDetails = new StaveDetails(node);
-      expect(staffDetails.getStaveLines()).toBe(5);
+      const staveDetails = new StaveDetails(node);
+      expect(staveDetails.getStaveLines()).toBe(5);
     });
 
     it('defaults to 5 when invalid', () => {
       const staffLines = xml.staffLines({ value: NaN });
       const node = xml.staffDetails({ staffLines });
 
-      const staffDetails = new StaveDetails(node);
+      const staveDetails = new StaveDetails(node);
 
-      expect(staffDetails.getStaveLines()).toBe(5);
+      expect(staveDetails.getStaveLines()).toBe(5);
     });
   });
 });


### PR DESCRIPTION
This PR updates terms that use "staff" to use "stave" instead. Direct-ish references to musicXML were left untouched.

https://en.wikipedia.org/wiki/Staff_(music)

When I initially studied musicXML and vexflow, I didn't realize these terms were interchangeable. I thought "stave" / "staves" were the plural of "staff", so I was confused when I saw "stave" and "staff" used interchangeably. Hopefully this saves someone else the headache.

Good thing I used TypeScript.