### PR TITLE
Support compressed MusicXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ const div = document.createElement('div');
 div.style.width = `${width}px`;
 div.style.height = `${height}px`;
 
-const xml = 'some valid musicXML'; // see tests/integration/__data__ for valid musicXML documents
+const musicXML = 'some valid musicXML'; // see tests/integration/__data__ for valid musicXML documents
 
-vexml.Vexml.render({ element: div, width: width, xml: xml });
+vexml.Vexml.fromMusicXML(musicXML).render({ element: div, width: width });
 ```
 
 This will render a child SVG element whose height will automatically adjust to fit the container. There is currently no option to disable this.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Before you run any commands, install the dependencies.
 yarn install
 ```
 
+### Running the Dev Server
+
+In order to run a dev server that hot reloads `vexml` changes, run:
+
+```sh
+yarn dev
+```
+
+You should be able to "save" MusicXML documents in localstorage using the dev app, which will cause the documents to survive refreshing the page.
+
 ### Running Tests
 
 In order to run tests on x86 architecture, run:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:ci": "docker run --rm vexml:latest yarn jest --runInBand --ci"
   },
   "dependencies": {
+    "jszip": "3.10.1",
     "vxflw-early-access": "5.0.0-alpha.11"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@types/bootstrap": "^5.2.9",
     "@types/jest": "^27.4.1",
     "@types/jquery": "^3.5.27",
+    "@types/jszip": "3.4.1",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -46,10 +46,9 @@ function Vexml({ musicXml, containerId, onRender }: VexmlProps) {
     const start = new Date();
 
     try {
-      vexml.Vexml.render({
+      vexml.Vexml.fromMusicXML(musicXml).render({
         element,
         width,
-        musicXml,
       });
       onRender({
         type: 'success',

--- a/src/README.md
+++ b/src/README.md
@@ -1,8 +1,9 @@
 # src
 
-`vexml` is composed of four libraries:
+`vexml` is composed of:
 
 - [musicxml](./musicxml/README.md): Organize data from a MusicXML document so that it can be read easily in TypeScript.
+- [mxl](./mxl/README.md): Organize data from a MXL document so that it can be read easily in TypeScript.
 - [rendering](./rendering/README.md): Take MusicXML data and transform it into `vexflow` objects.
 - [drawables](./drawables/README.md): Extend `vexflow`'s drawing capabilities.
 - `util`: Miscellaneous functionality that doesn't neatly fit into either library or needs to be shared.

--- a/src/musicxml/musicxml.ts
+++ b/src/musicxml/musicxml.ts
@@ -9,11 +9,15 @@ import { ScorePartwise } from './scorepartwise';
 export class MusicXml {
   constructor(private root: Document) {}
 
-  /** Returns the first <score-partwise> of the document or null when missing. */
-  getScorePartwise(): ScorePartwise | null {
+  /**
+   * Returns the first <score-partwise> of the document.
+   *
+   * @throws {Error} when the root does not contain a <score-partwise> element. It does not check for deep validity.
+   */
+  getScorePartwise(): ScorePartwise {
     const node = this.root.getElementsByTagName('score-partwise').item(0);
     if (!node) {
-      return null;
+      throw new Error('could not find a <score-partwise> element');
     }
     return new ScorePartwise(NamedElement.of(node));
   }

--- a/src/musicxml/musicxml.ts
+++ b/src/musicxml/musicxml.ts
@@ -21,4 +21,10 @@ export class MusicXml {
     }
     return new ScorePartwise(NamedElement.of(node));
   }
+
+  /** Returns the string representation of the document. */
+  getDocumentString(): string {
+    const serializer = new XMLSerializer();
+    return serializer.serializeToString(this.root);
+  }
 }

--- a/src/mxl/README.md
+++ b/src/mxl/README.md
@@ -1,0 +1,17 @@
+# mxl
+
+The `mxl` library is responsible for interfacing with [MXL](https://www.w3.org/2021/06/musicxml40/tutorial/compressed-mxl-files/) compressed files.
+
+## Intent
+
+### Goals
+
+- **DO** provide an interface for getting data from an MXL archive.
+- **DO** artifically flatten the XML structure of a MXL document.
+- **DO** conform data from the MXL document to reasonable defaults when needed.
+
+### Non-goals
+
+- **DO NOT** map 1:1 TypeScript classes to MXL elements.
+- **DO NOT** mutate data in a MXL document.
+- **DO NOT** parse its MusicXML data into `musicxml` elements.

--- a/src/mxl/container.ts
+++ b/src/mxl/container.ts
@@ -1,0 +1,19 @@
+import { NamedElement } from '@/util';
+import { Rootfile } from './rootfile';
+
+/**
+ * Starting with Version 2.0, the MusicXML format includes a standard zip compressed version. These zip files can
+ * contain multiple MusicXML files as well as other media files for images and sound. The container element is the
+ * document element for the META-INF/container.xml file. The container describes the starting point for the MusicXML
+ * version of the file, as well as alternate renditions such as PDF and audio versions of the musical score.
+ *
+ * See https://www.w3.org/2021/06/musicxml40/container-reference/elements/container/.
+ */
+export class Container {
+  constructor(private element: NamedElement<'container'>) {}
+
+  /** Returns the rootfiles of the container. Defaults to empty array. */
+  getRootfiles(): Rootfile[] {
+    return this.element.all('rootfile').map((node) => new Rootfile(node));
+  }
+}

--- a/src/mxl/index.ts
+++ b/src/mxl/index.ts
@@ -1,0 +1,3 @@
+export * from './mxl';
+export * from './container';
+export * from './rootfile';

--- a/src/mxl/mxl.ts
+++ b/src/mxl/mxl.ts
@@ -1,0 +1,52 @@
+import JSZip from 'jszip';
+import { Container } from './container';
+import { NamedElement } from '@/util';
+
+const META_PATH = 'META-INF/container.xml';
+const MUSICXML_MIME_TYPES = [
+  'text/xml',
+  'application/xml',
+  'application/x-xml',
+  'application/vnd.recordare.musicxml+xml',
+];
+
+/** Represents the manifest for a compressed MusicXML file. */
+export class MXL {
+  constructor(private blob: Blob) {}
+
+  /**
+   * Returns the MusicXML string.
+   * @throws {Error} when the blob cannot be handled like a MXL file.
+   */
+  async getMusicXml(): Promise<string> {
+    const zip = await JSZip.loadAsync(this.blob);
+
+    const xml = await zip.file(META_PATH)?.async('string');
+    if (typeof xml === 'undefined') {
+      throw new Error(`could not extract manifest from: ${META_PATH}`);
+    }
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, 'application/xml');
+    const node = doc.getElementsByTagName('container').item(0);
+    if (!node) {
+      throw new Error('could not locate a <container> element');
+    }
+
+    const container = new Container(NamedElement.of(node));
+    const path = container
+      .getRootfiles()
+      .find((rootfile) => MUSICXML_MIME_TYPES.includes(rootfile.getMediaType()))
+      ?.getFullPath();
+    if (typeof path === 'undefined') {
+      throw new Error(`could not find a <rootfile> with type: ${MUSICXML_MIME_TYPES.join(',')}`);
+    }
+
+    const musicXml = await zip.file(path)?.async('string');
+    if (typeof musicXml !== 'string') {
+      throw new Error(`could not find file with path: ${path}`);
+    }
+
+    return musicXml;
+  }
+}

--- a/src/mxl/rootfile.ts
+++ b/src/mxl/rootfile.ts
@@ -1,0 +1,20 @@
+import { NamedElement } from '@/util';
+
+/**
+ * The `<rootfile>` element describes each top-level file in the MusicXML container.
+ *
+ * See https://www.w3.org/2021/06/musicxml40/container-reference/elements/rootfile/.
+ */
+export class Rootfile {
+  constructor(private element: NamedElement<'rootfile'>) {}
+
+  /** Returns the full path of the root file. Defaults to empty string. */
+  getFullPath(): string {
+    return this.element.attr('full-path').withDefault('').str();
+  }
+
+  /** Returns the media type of the root file. Defaults to 'application/vnd.recordare.musicxml+xml'. */
+  getMediaType(): string {
+    return this.element.attr('media-type').withDefault('application/vnd.recordare.musicxml+xml').str();
+  }
+}

--- a/src/util/xml.ts
+++ b/src/util/xml.ts
@@ -1276,3 +1276,33 @@ export const pedal = createNamedElementFactory<'pedal', { type: string; line: st
     }
   }
 );
+
+export const container = createNamedElementFactory<'container', { rootfiles: NamedElement<'rootfiles'> }>(
+  'container',
+  (e, { rootfiles }) => {
+    if (rootfiles) {
+      e.append(rootfiles);
+    }
+  }
+);
+
+export const rootfiles = createNamedElementFactory<'rootfiles', { rootfiles: NamedElement<'rootfile'>[] }>(
+  'rootfiles',
+  (e, { rootfiles }) => {
+    if (rootfiles) {
+      e.append(...rootfiles);
+    }
+  }
+);
+
+export const rootfile = createNamedElementFactory<'rootfile', { fullPath: string; mediaType: string }>(
+  'rootfile',
+  (e, { fullPath, mediaType }) => {
+    if (fullPath) {
+      e.setAttribute('full-path', fullPath);
+    }
+    if (mediaType) {
+      e.setAttribute('media-type', mediaType);
+    }
+  }
+);

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -3,20 +3,52 @@ import * as rendering from '@/rendering';
 
 export type RenderOptions = {
   element: HTMLDivElement | HTMLCanvasElement;
-  musicXml: string;
-  width: number;
   config?: Partial<rendering.Config>;
+  width: number;
 };
 
 /** Vexml contains the core operation of this library: rendering MusicXML in a web browser. */
 export class Vexml {
-  /** Renders a MusicXML document to an HTML element. */
-  static render(opts: RenderOptions): rendering.ScoreRendering {
-    const parser = new DOMParser();
-    const root = parser.parseFromString(opts.musicXml, 'application/xml');
+  constructor(private musicXml: Document) {}
 
+  /** Creates an instance from a MusicXML string. */
+  static fromMusicXML(musicXML: string): Vexml {
+    const parser = new DOMParser();
+    const root = parser.parseFromString(musicXML, 'application/xml');
+    return new Vexml(root);
+  }
+
+  /** Creates an instance from a buffer containing a MusicXML string. */
+  static fromBuffer(buffer: Buffer): Vexml {
+    return Vexml.fromMusicXML(buffer.toString());
+  }
+
+  /** Creates an instance from a URL that corresponds to a MusicXML string. */
+  static async fromURL(url: string | URL | Request): Promise<Vexml> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`expected response to be ok, got: ${response.statusText} (${response.status})`);
+    }
+    const musicXML = await response.text();
+    return Vexml.fromMusicXML(musicXML);
+  }
+
+  /** Creates an instance from a Blob of a MusicXML string or a .mxl archive (compressed MusicXML). */
+  static async fromBlob(blob: Blob): Promise<Vexml> {
+    // TODO, use a real implementation.
+    return Vexml.fromMusicXML('');
+  }
+
+  /** Creates an instance from a File of a MusicXML string or a .mxl archive (compressed MusicXML). */
+  static async fromFile(file: File): Promise<Vexml> {
+    return Vexml.fromBlob(file);
+  }
+
+  /** Renders the vexml instance to an HTML element. */
+  render(opts: RenderOptions): rendering.ScoreRendering {
     const config = { ...rendering.DEFAULT_CONFIG, ...opts.config };
-    const scorePartwise = new musicxml.MusicXml(root).getScorePartwise();
+
+    const scorePartwise = new musicxml.MusicXml(this.musicXml).getScorePartwise();
 
     const score = new rendering.Score({
       config,

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -9,12 +9,17 @@ export type RenderOptions = {
 
 /** Vexml contains the core operation of this library: rendering MusicXML in a web browser. */
 export class Vexml {
-  constructor(private musicXml: Document) {}
+  constructor(private musicXml: musicxml.MusicXml) {}
 
   /** Creates an instance from a MusicXML string. */
   static fromMusicXML(musicXML: string): Vexml {
-    const parser = new DOMParser();
-    const root = parser.parseFromString(musicXML, 'application/xml');
+    const doc = new DOMParser().parseFromString(musicXML, 'application/xml');
+
+    const root = new musicxml.MusicXml(doc);
+    if (!root.getScorePartwise()) {
+      throw new Error(`invalid MusicXML document, could not find a <score-partwise> element`);
+    }
+
     return new Vexml(root);
   }
 
@@ -48,12 +53,10 @@ export class Vexml {
   render(opts: RenderOptions): rendering.ScoreRendering {
     const config = { ...rendering.DEFAULT_CONFIG, ...opts.config };
 
-    const scorePartwise = new musicxml.MusicXml(this.musicXml).getScorePartwise();
-
     const score = new rendering.Score({
       config,
       musicXml: {
-        scorePartwise,
+        scorePartwise: this.musicXml.getScorePartwise(),
       },
     });
 

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -17,7 +17,7 @@ export class Vexml {
 
     const root = new musicxml.MusicXml(doc);
     if (!root.getScorePartwise()) {
-      throw new Error(`invalid MusicXML document, could not find a <score-partwise> element`);
+      throw new Error(`invalid MusicXML document: must have a <score-partwise> element`);
     }
 
     return new Vexml(root);

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -38,13 +38,13 @@ export class Vexml {
     return Vexml.fromMusicXML(musicXML);
   }
 
-  /** Creates an instance from a Blob of a MusicXML string or a .mxl archive (compressed MusicXML). */
+  /** Creates an instance from a Blob of a MusicXML string or a .mxl archive (compressed MusicXML file). */
   static async fromBlob(blob: Blob): Promise<Vexml> {
     // TODO, use a real implementation.
     return Vexml.fromMusicXML('');
   }
 
-  /** Creates an instance from a File of a MusicXML string or a .mxl archive (compressed MusicXML). */
+  /** Creates an instance from a File of a MusicXML string or a .mxl archive (compressed MusicXML file). */
   static async fromFile(file: File): Promise<Vexml> {
     return Vexml.fromBlob(file);
   }

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -14,12 +14,7 @@ export class Vexml {
   /** Creates an instance from a MusicXML string. */
   static fromMusicXML(musicXML: string): Vexml {
     const doc = new DOMParser().parseFromString(musicXML, 'application/xml');
-
     const root = new musicxml.MusicXml(doc);
-    if (!root.getScorePartwise()) {
-      throw new Error(`invalid MusicXML document: must have a <score-partwise> element`);
-    }
-
     return new Vexml(root);
   }
 

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -89,4 +89,9 @@ export class Vexml {
       width: opts.width,
     });
   }
+
+  /** Returns the document string. */
+  getDocumentString(): string {
+    return this.musicXml.getDocumentString();
+  }
 }

--- a/tests/integration/lilypond.test.ts
+++ b/tests/integration/lilypond.test.ts
@@ -154,9 +154,10 @@ describe('lilypond', () => {
   ])(`$filename ($width px)`, async (t) => {
     const { document, vexmlDiv, screenshotElementSelector } = setup();
 
-    Vexml.render({
+    const buffer = fs.readFileSync(path.join(DATA_DIR, t.filename));
+
+    Vexml.fromBuffer(buffer).render({
       element: vexmlDiv,
-      musicXml: fs.readFileSync(path.join(DATA_DIR, t.filename)).toString(),
       width: t.width,
     });
 

--- a/tests/unit/musicxml/musicxml.test.ts
+++ b/tests/unit/musicxml/musicxml.test.ts
@@ -13,10 +13,10 @@ describe(MusicXml, () => {
       expect(musicXml.getScorePartwise()).toStrictEqual(new ScorePartwise(scorePartwise));
     });
 
-    it('returns null when <score-partwise> is missing', () => {
+    it('throws when <score-partwise> is missing', () => {
       const root = xml.createDocument();
       const musicXml = new MusicXml(root);
-      expect(musicXml.getScorePartwise()).toBeNull();
+      expect(() => musicXml.getScorePartwise()).toThrow();
     });
   });
 });

--- a/tests/unit/mxl/container.test.ts
+++ b/tests/unit/mxl/container.test.ts
@@ -1,0 +1,22 @@
+import { Container, Rootfile } from '@/mxl';
+import { xml } from '@/util';
+
+describe(Container, () => {
+  describe('getRootfiles', () => {
+    it('returns the rootfiles of the container', () => {
+      const rootfile1 = xml.rootfile({ fullPath: 'foo.musicxml' });
+      const rootfile2 = xml.rootfile({ fullPath: 'bar.musicxml' });
+      const node = xml.container({ rootfiles: xml.rootfiles({ rootfiles: [rootfile1, rootfile2] }) });
+
+      const container = new Container(node);
+
+      expect(container.getRootfiles()).toStrictEqual([new Rootfile(rootfile1), new Rootfile(rootfile2)]);
+    });
+
+    it('defaults to an empty array when missing', () => {
+      const node = xml.container();
+      const container = new Container(node);
+      expect(container.getRootfiles()).toStrictEqual([]);
+    });
+  });
+});

--- a/tests/unit/mxl/rootfile.test.ts
+++ b/tests/unit/mxl/rootfile.test.ts
@@ -1,0 +1,31 @@
+import { Rootfile } from '@/mxl';
+import { xml } from '@/util';
+
+describe(Rootfile, () => {
+  describe('getFullPath', () => {
+    it('returns the full path of the rootfile', () => {
+      const node = xml.rootfile({ fullPath: 'foo' });
+      const rootfile = new Rootfile(node);
+      expect(rootfile.getFullPath()).toBe('foo');
+    });
+
+    it('defaults to an empty string when missing', () => {
+      const node = xml.rootfile();
+      const rootfile = new Rootfile(node);
+      expect(rootfile.getFullPath()).toBe('');
+    });
+  });
+
+  describe('getMediaType', () => {
+    it('returns the media type of the rootfile', () => {
+      const node = xml.rootfile({ mediaType: 'text/foo' });
+      const rootfile = new Rootfile(node);
+      expect(rootfile.getMediaType()).toBe('text/foo');
+    });
+
+    it('defaults to musicxml mime type when missing', () => {});
+    const node = xml.rootfile();
+    const rootfile = new Rootfile(node);
+    expect(rootfile.getMediaType()).toBe('application/vnd.recordare.musicxml+xml');
+  });
+});

--- a/tests/unit/util/vexml.test.ts
+++ b/tests/unit/util/vexml.test.ts
@@ -10,13 +10,13 @@ describe(Vexml, () => {
     });
 
     it('runs without crashing', () => {
-      expect(() => Vexml.render({ element: div, musicXml: XML, width: 2000 })).not.toThrow();
+      expect(() => Vexml.fromMusicXML(MUSIC_XML).render({ element: div, width: 2000 })).not.toThrow();
     });
   });
 });
 
 // See https://lilypond.org/doc/v2.23/input/regression/musicxml/collated-files.html
-const XML = `<?xml version="1.0" encoding="UTF-8"?>
+const MUSIC_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.0 Partwise//EN"
                                 "http://www.musicxml.org/dtds/partwise.dtd">
 <score-partwise>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,6 +1782,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/jszip@3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jszip/-/jszip-3.4.1.tgz#e7a4059486e494c949ef750933d009684227846f"
+  integrity sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==
+  dependencies:
+    jszip "*"
+
 "@types/node@*":
   version "20.8.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.2.tgz#d76fb80d87d0d8abfe334fc6d292e83e5524efc4"
@@ -2581,6 +2588,11 @@ core-js-compat@^3.31.0, core-js-compat@^3.32.2:
   integrity sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==
   dependencies:
     browserslist "^4.22.1"
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cosmiconfig@8.3.6:
   version "8.3.6"
@@ -3690,6 +3702,11 @@ ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -3719,7 +3736,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3892,6 +3909,11 @@ isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4491,6 +4513,16 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jszip@*, jszip@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 keyv@^4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"
@@ -4515,6 +4547,13 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -4907,6 +4946,11 @@ pac-resolver@^7.0.0:
     ip "^1.1.8"
     netmask "^2.0.2"
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -5060,6 +5104,11 @@ pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 progress@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -5189,6 +5238,19 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.1"
@@ -5348,6 +5410,11 @@ safe-array-concat@^1.0.1:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -5406,6 +5473,11 @@ set-function-name@^2.0.0:
     define-data-property "^1.0.1"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.0"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -5572,6 +5644,13 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -5911,7 +5990,7 @@ urlpattern-polyfill@9.0.0:
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz#bc7e386bb12fd7898b58d1509df21d3c29ab3460"
   integrity sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==


### PR DESCRIPTION
This PR fixes #172.

- [X] Add MXL support.
- [X] Add `Container` and `Rootfile` classes and tests.
- [X] Update documentation regarding the `mxl` library.
- [X] Update https://vexml.dev to handle mxl files.
- [X] Tested locally with [Sarabande_de_Haendel.zip](https://github.com/stringsync/vexml/files/13420219/Sarabande_de_Haendel.zip).
- [X] Update `Vexml` rendering signature.
- [X] Support several input types.
- [X] Change `musicxml.MusicXml` and `mxl.Mxl` functions to throw when there are problems.
