### PR TITLE
Fix spanners extra width calculation

### DIFF
--- a/src/rendering/chorus.ts
+++ b/src/rendering/chorus.ts
@@ -114,11 +114,7 @@ export class Chorus {
       );
 
       const vfFormatter = new vexflow.Formatter();
-      return (
-        vfFormatter.joinVoices(vfVoices).preCalculateMinTotalWidth(vfVoices) +
-        spanners.getPadding() +
-        this.config.VOICE_PADDING
-      );
+      return vfFormatter.joinVoices(vfVoices).preCalculateMinTotalWidth(vfVoices) + this.config.VOICE_PADDING;
     }
     return 0;
   }

--- a/src/rendering/measurefragment.ts
+++ b/src/rendering/measurefragment.ts
@@ -412,7 +412,11 @@ export class MeasureFragment {
       return 0;
     }
 
-    return vfFormatter.preCalculateMinTotalWidth(vfVoices) + spanners.getPadding() + this.config.VOICE_PADDING;
+    return (
+      vfFormatter.preCalculateMinTotalWidth(vfVoices) +
+      spanners.getExtraMeasureFragmentWidth(opts.address) +
+      this.config.VOICE_PADDING
+    );
   }
 
   private getNonVoiceWidth(): number {

--- a/src/rendering/spanners.ts
+++ b/src/rendering/spanners.ts
@@ -8,6 +8,7 @@ import { OctaveShift, OctaveShiftRendering } from './octaveshift';
 import { SpannerData } from './types';
 import { SpannerMap } from './spannermap';
 import * as util from '@/util';
+import { Address } from './address';
 
 /** The result of rendering spanners. */
 export type SpannersRendering = {
@@ -32,8 +33,8 @@ export class Spanners {
   private octaveShifts = SpannerMap.keyless<OctaveShift>();
 
   /** Returns the additional padding needed to accommodate some spanners. */
-  getPadding(): number {
-    return util.sum(this.tuplets.values().map((tuplet) => tuplet.getPadding()));
+  getExtraMeasureFragmentWidth(address: Address<'measurefragment'>): number {
+    return util.sum(this.tuplets.values().map((tuplet) => tuplet.getExtraMeasureFragmentWidth(address)));
   }
 
   /** Extracts and processes all the spanners within the given data. */

--- a/src/rendering/tuplet.ts
+++ b/src/rendering/tuplet.ts
@@ -3,6 +3,7 @@ import * as util from '@/util';
 import * as conversions from './conversions';
 import { SpannerData } from './types';
 import { SpannerMap } from './spannermap';
+import { Address } from './address';
 
 const TUPLET_PADDING_PER_NOTE = 10;
 
@@ -18,6 +19,7 @@ export type TupletRendering = {
 export type TupletFragment =
   | {
       type: 'start';
+      address: Address<'voice'>;
       vexflow: {
         note: vexflow.Note;
         location: vexflow.TupletLocation;
@@ -26,6 +28,7 @@ export type TupletFragment =
     }
   | {
       type: 'unspecified' | 'stop';
+      address: Address<'voice'>;
       vexflow: {
         note: vexflow.Note;
       };
@@ -59,6 +62,7 @@ export class Tuplet {
         Tuplet.commit(
           {
             type: 'start',
+            address: data.address,
             vexflow: {
               location: conversions.fromAboveBelowToTupletLocation(tuplet.getPlacement()),
               note: data.vexflow.staveNote,
@@ -72,6 +76,7 @@ export class Tuplet {
         Tuplet.commit(
           {
             type: 'stop',
+            address: data.address,
             vexflow: {
               note: data.vexflow.staveNote,
             },
@@ -83,6 +88,7 @@ export class Tuplet {
         Tuplet.commit(
           {
             type: 'unspecified',
+            address: data.address,
             vexflow: {
               note: data.vexflow.staveNote,
             },
@@ -117,8 +123,11 @@ export class Tuplet {
   }
 
   /** Returns the padding required by the tuplet based on its size. */
-  getPadding(): number {
-    return this.fragments.length * TUPLET_PADDING_PER_NOTE;
+  getExtraMeasureFragmentWidth(address: Address<'measurefragment'>): number {
+    return (
+      this.fragments.filter((fragment) => fragment.address.isMemberOf('measurefragment', address)).length *
+      TUPLET_PADDING_PER_NOTE
+    );
   }
 
   /** Renders a tuplet. */


### PR DESCRIPTION
This PR is a no-op due to the way `Spanners` are instantiated for each `MeasureFragment` at width measuring time. However, I wanted to make it more semantically accurate by explicitly checking tuplet membership within a measure fragment when deciding how much extra width to add.