### PR TITLE
Do not render incomplete beams

### DIFF
--- a/src/rendering/beam.ts
+++ b/src/rendering/beam.ts
@@ -8,7 +8,7 @@ import { SpannerMap } from './spannermap';
 export type BeamRendering = {
   type: 'beam';
   vexflow: {
-    beam: vexflow.Beam;
+    beam: vexflow.Beam | null;
   };
 };
 
@@ -81,7 +81,7 @@ export class Beam {
   /** Renders the beam. */
   render(): BeamRendering {
     const vfStemmableNotes = this.fragments.map((fragment) => fragment.vexflow.stemmableNote);
-    const beam = new vexflow.Beam(vfStemmableNotes);
+    const beam = vfStemmableNotes.length > 1 ? new vexflow.Beam(vfStemmableNotes) : null;
 
     return {
       type: 'beam',

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -162,7 +162,7 @@ export class Score {
 
     // Draw vexflow.Beam elements.
     spannersRendering.beams.forEach((beam) => {
-      beam.vexflow.beam.setContext(vfContext).draw();
+      beam.vexflow.beam?.setContext(vfContext).draw();
     });
 
     // Draw vexflow.StaveTie elements.


### PR DESCRIPTION
This PR fixes the issue called out in https://github.com/stringsync/vexml/issues/78#issuecomment-1874242859.

Before this PR, `vexflow.Beam` objects would try to be created with less than 2 stemmable notes, during the measurement phase or due to invalid MusicXML documents. This would cause a `vexflow` error to be thrown.

After this PR, we will simply check the stemmable notes length and ignore underspecified beams.