### PR TITLE
Add canvas support

### DIFF
--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -87,9 +87,8 @@ export const SourceDisplay = (props: SourceProps) => {
   const svgButtonId = useId();
   const canvasButtonId = useId();
   const vexmlModeName = useId();
-  const [vexmlMode, setVexmlMode] = useState<VexmlMode>('svg');
   const onVexmlModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setVexmlMode(e.target.value as VexmlMode);
+    props.onUpdate({ ...props.source, vexmlMode: e.target.value as VexmlMode });
   };
 
   return (
@@ -145,7 +144,7 @@ export const SourceDisplay = (props: SourceProps) => {
               name={vexmlModeName}
               value="svg"
               id={svgButtonId}
-              checked={vexmlMode === 'svg'}
+              checked={props.source.vexmlMode === 'svg'}
               onChange={onVexmlModeChange}
             />
             <label className="btn btn-outline-info" htmlFor={svgButtonId}>
@@ -158,7 +157,7 @@ export const SourceDisplay = (props: SourceProps) => {
               name={vexmlModeName}
               value="canvas"
               id={canvasButtonId}
-              checked={vexmlMode === 'canvas'}
+              checked={props.source.vexmlMode === 'canvas'}
               onChange={onVexmlModeChange}
             />
             <label className="btn btn-outline-info" htmlFor={canvasButtonId}>
@@ -218,7 +217,7 @@ export const SourceDisplay = (props: SourceProps) => {
           <div className="d-flex justify-content-center">
             <Vexml
               musicXML={musicXML}
-              mode={vexmlMode}
+              mode={props.source.vexmlMode}
               onResult={setVexmlResult}
               onClick={isVexmlClickEnabled ? onVexmlClick : undefined}
             />

--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -11,6 +11,7 @@ import { downloadSvgAsImage } from '../util/downloadSvgAsImage';
 import { convertFontToBase64 } from '../util/convertFontToBase64';
 import { useNextKey } from '../hooks/useNextKey';
 import { EVENT_LOG_CAPACITY, EventLog, EventLogCard } from './EventLogCard';
+import { downloadCanvasAsImage } from '../util/downloadCanvasAsImage';
 
 const BUG_REPORT_HREF = `https://github.com/stringsync/vexml/issues/new?assignees=&labels=&projects=&template=bug-report.md&title=[BUG] (v${VEXML_VERSION}): <YOUR TITLE>`;
 const SNAPSHOT_NAME = `vexml_dev_${VEXML_VERSION.replace(/\./g, '_')}.png`;
@@ -42,7 +43,7 @@ export const SourceDisplay = (props: SourceProps) => {
   useTooltip(snapshotButtonRef, 'top', SNAPSHOT_NAME);
 
   const element = vexmlResult.type === 'success' ? vexmlResult.element : null;
-  const snapshotButtonDisabled = !(element instanceof SVGElement);
+  const snapshotButtonDisabled = !(element instanceof SVGElement) && !(element instanceof HTMLCanvasElement);
   const onSnapshotClick = async () => {
     if (element instanceof SVGElement) {
       downloadSvgAsImage(element, {
@@ -50,6 +51,9 @@ export const SourceDisplay = (props: SourceProps) => {
         fontFamily: FONT_FAMILY,
         fontBase64: await convertFontToBase64(FONT_URL),
       });
+    }
+    if (element instanceof HTMLCanvasElement) {
+      downloadCanvasAsImage(element, SNAPSHOT_NAME);
     }
   };
 

--- a/site/src/components/SourceWorkspace.tsx
+++ b/site/src/components/SourceWorkspace.tsx
@@ -38,7 +38,7 @@ export const SourceWorkspace = (props: SourceWorkspaceProps) => {
   };
 
   const onAddClick = (index: number) => () => {
-    const keyedSource: Keyed<Source> = { key: nextKey(), value: { type: 'local', musicXML: '' } };
+    const keyedSource: Keyed<Source> = { key: nextKey(), value: { type: 'local', musicXML: '', vexmlMode: 'svg' } };
     const nextKeyedSources = [...keyedSources];
     nextKeyedSources.splice(index, 0, keyedSource);
     setKeyedSources(nextKeyedSources);

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -84,8 +84,11 @@ export const Vexml = (props: VexmlProps) => {
       let element: HTMLCanvasElement | SVGElement;
       if (container instanceof HTMLDivElement) {
         element = container.firstElementChild as SVGElement;
-        element.style.backgroundColor = 'white'; // needed for non-transparent background downloadSvgAsImage
+        // Now that the <svg> is created, we can set the style for screenshots.
+        element.style.backgroundColor = 'white';
       } else if (container instanceof HTMLCanvasElement) {
+        // The <canvas> image background is transparent, and there's not much we can do to change that without
+        // significantly changing the vexml rendering.
         element = container;
       } else {
         throw new Error(`invalid container: ${container}`);

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -7,22 +7,31 @@ const THROTTLE_DELAY_MS = 50;
 
 export type VexmlProps = {
   musicXML: string;
+  mode: VexmlMode;
   onResult: (result: VexmlResult) => void;
   onClick?: vexml.ClickEventListener;
 };
 
+export type VexmlMode = 'svg' | 'canvas';
+
 export type VexmlResult =
   | { type: 'none' }
   | { type: 'empty' }
-  | { type: 'success'; start: Date; end: Date; width: number; svg: SVGElement }
+  | { type: 'success'; start: Date; end: Date; width: number; element: HTMLCanvasElement | SVGElement }
   | { type: 'error'; error: Error; start: Date; end: Date; width: number };
 
 export const Vexml = (props: VexmlProps) => {
   const musicXML = props.musicXML;
+  const mode = props.mode;
   const onResult = props.onResult;
   const onClick = props.onClick;
-  const containerRef = useRef<HTMLDivElement>(null);
-  const width = useWidth(containerRef, THROTTLE_DELAY_MS);
+
+  const divContainerRef = useRef<HTMLDivElement>(null);
+  const canvasContainerRef = useRef<HTMLCanvasElement>(null);
+
+  const divWidth = useWidth(divContainerRef, THROTTLE_DELAY_MS);
+  const canvasWidth = useWidth(canvasContainerRef, THROTTLE_DELAY_MS);
+  const width = mode === 'svg' ? divWidth : canvasWidth;
 
   const [rendering, setRendering] = useState<vexml.Rendering | null>(null);
 
@@ -52,11 +61,16 @@ export const Vexml = (props: VexmlProps) => {
       return;
     }
 
-    const element = containerRef.current;
-    if (!element) {
+    let container: HTMLDivElement | HTMLCanvasElement | null = null;
+    if (mode === 'canvas') {
+      container = canvasContainerRef.current as HTMLCanvasElement;
+    }
+    if (mode === 'svg') {
+      container = divContainerRef.current as HTMLDivElement;
+    }
+    if (!container) {
       return;
     }
-
     if (width === 0) {
       return;
     }
@@ -64,19 +78,24 @@ export const Vexml = (props: VexmlProps) => {
     const start = new Date();
 
     try {
-      const rendering = vexml.Vexml.fromMusicXML(musicXML).renderSVG({
-        container: element,
-        width,
-      });
+      const rendering = vexml.Vexml.fromMusicXML(musicXML).render({ container, width });
       setRendering(rendering);
 
-      const svg = element.firstChild as SVGElement;
-      svg.style.backgroundColor = 'white'; // needed for non-transparent background downloadSvgAsImage
+      let element: HTMLCanvasElement | SVGElement;
+      if (container instanceof HTMLDivElement) {
+        element = container.firstElementChild as SVGElement;
+        element.style.backgroundColor = 'white'; // needed for non-transparent background downloadSvgAsImage
+      } else if (container instanceof HTMLCanvasElement) {
+        element = container;
+      } else {
+        throw new Error(`invalid container: ${container}`);
+      }
+
       onResult({
         type: 'success',
         start,
         end: new Date(),
-        svg,
+        element,
         width,
       });
     } catch (e) {
@@ -90,12 +109,20 @@ export const Vexml = (props: VexmlProps) => {
     }
 
     return () => {
-      const firstChild = element.firstChild;
-      if (firstChild) {
-        element.removeChild(firstChild);
+      if (container instanceof HTMLDivElement) {
+        container.firstElementChild?.remove();
       }
     };
-  }, [musicXML, width, onResult]);
+  }, [musicXML, mode, width, onResult]);
 
-  return <div className="w-100 position-relative" ref={containerRef}></div>;
+  return (
+    <>
+      <div className="w-100" ref={divContainerRef} style={{ display: mode === 'svg' ? 'block' : 'none' }}></div>
+      <canvas
+        className="w-100"
+        ref={canvasContainerRef}
+        style={{ display: mode === 'canvas' ? 'block' : 'none' }}
+      ></canvas>
+    </>
+  );
 };

--- a/site/src/hooks/useSources.ts
+++ b/site/src/hooks/useSources.ts
@@ -1,8 +1,8 @@
-import { EXAMPLES, DEFAULT_EXAMPLE_PATH, LOCAL_STORAGE_VEXML_SOURCES_KEY } from '../constants';
+import { DEFAULT_EXAMPLE_PATH, LOCAL_STORAGE_VEXML_SOURCES_KEY } from '../constants';
 import { Source } from '../types';
 import { useJsonLocalStorage } from './useJsonLocalStorage';
 
-const DEFAULT_SOURCES: Source[] = [{ type: 'example', path: DEFAULT_EXAMPLE_PATH }];
+const DEFAULT_SOURCES: Source[] = [{ type: 'example', path: DEFAULT_EXAMPLE_PATH, vexmlMode: 'svg' }];
 
 export const useSources = () => {
   const [sources, setSources] = useJsonLocalStorage(LOCAL_STORAGE_VEXML_SOURCES_KEY, [], isSources);
@@ -18,6 +18,9 @@ const isSources = (data: unknown): data is Source[] =>
   Array.isArray(data) &&
   data.every((item): item is Source => {
     if (typeof item !== 'object') {
+      return false;
+    }
+    if (item.vexmlMode !== 'svg' && item.vexmlMode !== 'canvas') {
       return false;
     }
     switch (item.type) {

--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -3,14 +3,17 @@ export type Source =
   | {
       type: 'local';
       musicXML: string;
+      vexmlMode: VexmlMode;
     }
   | {
       type: 'remote';
       url: string;
+      vexmlMode: VexmlMode;
     }
   | {
       type: 'example';
       path: string;
+      vexmlMode: VexmlMode;
     };
 
 /** A wrapper for keying values. */
@@ -18,3 +21,6 @@ export type Keyed<T> = {
   key: string;
   value: T;
 };
+
+/** The modes for rendering vexml. */
+export type VexmlMode = 'svg' | 'canvas';

--- a/site/src/util/downloadCanvasAsImage.ts
+++ b/site/src/util/downloadCanvasAsImage.ts
@@ -1,0 +1,12 @@
+export function downloadCanvasAsImage(canvas: HTMLCanvasElement, imageName: string) {
+  // Convert the canvas to a data URL
+  const dataUrl = canvas.toDataURL('image/png');
+
+  // Create a link element for downloading
+  const link = document.createElement('a');
+  document.body.appendChild(link); // Firefox requires the link to be in the body
+  link.setAttribute('href', dataUrl);
+  link.setAttribute('download', imageName);
+  link.click();
+  document.body.removeChild(link); // Remove the link when done
+}

--- a/site/src/util/downloadSvgAsImage.ts
+++ b/site/src/util/downloadSvgAsImage.ts
@@ -1,5 +1,5 @@
 export function downloadSvgAsImage(
-  svgElement: SVGElement,
+  svg: SVGElement,
   opts: {
     imageName: string;
     fontFamily: string;
@@ -15,11 +15,11 @@ export function downloadSvgAsImage(
     }
   `;
   styleElement.innerHTML = fontFaceRule;
-  svgElement.prepend(styleElement);
+  svg.prepend(styleElement);
 
   // Serialize the SVG to a string
   const serializer = new XMLSerializer();
-  const svgString = serializer.serializeToString(svgElement);
+  const svgString = serializer.serializeToString(svg);
   const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
 
   const URL = window.URL || window.webkitURL || window;

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -5,16 +5,12 @@ import { Config } from './config';
 /** The result of rendering MusicXML. */
 export class Rendering {
   private config: Config;
-  private bridge: events.NativeBridge<SVGElement | HTMLCanvasElement, keyof EventMap>;
+  private bridge: events.NativeBridge<keyof EventMap>;
   private topic: events.Topic<EventMap>;
 
   private tally: { [K in keyof EventMap]?: number } = {};
 
-  constructor(opts: {
-    config: Config;
-    bridge: events.NativeBridge<SVGElement | HTMLCanvasElement, keyof EventMap>;
-    topic: events.Topic<EventMap>;
-  }) {
+  constructor(opts: { config: Config; bridge: events.NativeBridge<keyof EventMap>; topic: events.Topic<EventMap> }) {
     this.config = opts.config;
     this.bridge = opts.bridge;
     this.topic = opts.topic;

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -113,7 +113,7 @@ export class Score {
     const staves = measureFragments.flatMap((measureFragment) => measureFragment.parts).flatMap((part) => part.staves);
 
     // Prepare the vexflow rendering objects.
-    const vfRenderer = new vexflow.Renderer(opts.container, vexflow.Renderer.Backends.SVG).resize(opts.width, y);
+    const vfRenderer = this.getVfRenderer(opts.container).resize(opts.width, y);
     const vfContext = vfRenderer.getContext();
 
     // Draw the title.
@@ -274,6 +274,13 @@ export class Score {
       config: this.config,
       text: this.musicXML.scorePartwise?.getTitle() ?? '',
     });
+  }
+
+  private getVfRenderer(container: HTMLDivElement | HTMLCanvasElement) {
+    if (container instanceof HTMLCanvasElement) {
+      return new vexflow.Renderer(container, vexflow.Renderer.Backends.CANVAS);
+    }
+    return new vexflow.Renderer(container, vexflow.Renderer.Backends.SVG);
   }
 
   private getTopSystemDistance(systems: System[]) {

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -1,6 +1,5 @@
 import * as vexflow from 'vexflow';
 import * as musicxml from '@/musicxml';
-import * as spatial from '@/spatial';
 import { Address } from './address';
 
 /** Data for a spanner. */

--- a/tests/integration/lilypond.test.ts
+++ b/tests/integration/lilypond.test.ts
@@ -156,7 +156,7 @@ describe('lilypond', () => {
 
     const buffer = fs.readFileSync(path.join(DATA_DIR, t.filename));
 
-    Vexml.fromBuffer(buffer).renderSVG({
+    Vexml.fromBuffer(buffer).render({
       container: vexmlDiv,
       width: t.width,
     });

--- a/tests/integration/vexml.test.ts
+++ b/tests/integration/vexml.test.ts
@@ -46,7 +46,7 @@ describe('vexml', () => {
 
     const buffer = fs.readFileSync(path.join(DATA_DIR, t.filename));
 
-    Vexml.fromBuffer(buffer).renderSVG({
+    Vexml.fromBuffer(buffer).render({
       container: vexmlDiv,
       width: t.width,
     });

--- a/tests/unit/util/vexml.test.ts
+++ b/tests/unit/util/vexml.test.ts
@@ -10,7 +10,7 @@ describe(Vexml, () => {
     });
 
     it('runs without crashing', () => {
-      expect(() => Vexml.fromMusicXML(MUSIC_XML).renderSVG({ container: div, width: 2000 })).not.toThrow();
+      expect(() => Vexml.fromMusicXML(MUSIC_XML).render({ container: div, width: 2000 })).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
This PR fixes #228.

- Rename `vexml.Vexml.renderSVG` to `vexml.Vexml.render`. Callers can opaquely provide an `HTMLDivElement | HTMLCanvasElement` for as a container, and vexml will detect and render the correct thing.
- Update site to have a toggle for SVG or Canvas on a per-source basis.
- Encode vexml rendering mode into the source data (which is in localstorage). That way, when developing locally, the rendering mode is preserved between loads.
- Add snapshot support for `<canvas>` elements. 