### PR TITLE
Create discrete cursor controls

### DIFF
--- a/site/src/components/CursorForm.tsx
+++ b/site/src/components/CursorForm.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { Cursor } from '../types';
+import { Select, SelectOptionGroup } from './Select';
+import { useNextKey } from '../hooks/useNextKey';
+import * as vexml from '@/index';
+
+const COLORS = ['#FC354C', '#FFB400', '#00BD9D', '#00A2FF', '#8A79AF'];
+
+const DEFAULT_PART_ID_KEY = 'vexml-default';
+
+export type CursorFormProps = {
+  partIds: string[];
+  onChange(cursors: Cursor[]): void;
+};
+
+export const CursorForm = (props: CursorFormProps) => {
+  const nextCursorId = useNextKey('cursor');
+  const [cursor, setCursor] = useState<Cursor>(() => ({
+    type: 'discrete',
+    id: nextCursorId(),
+    color: COLORS[0],
+    span: 'system',
+  }));
+  const [cursors, setCursors] = useState(new Array<Cursor>());
+
+  const colorSelectOptionGroups = COLORS.map<SelectOptionGroup<string>>((color) => ({
+    type: 'single',
+    option: { label: color, key: color, value: color },
+  }));
+
+  const cursorTypeSelectOptionGroups: Array<SelectOptionGroup<Cursor['type']>> = [
+    {
+      type: 'single',
+      option: { label: 'discrete', key: 'discrete', value: 'discrete' },
+    },
+  ];
+
+  const partIdSelectOptionGroups: Array<SelectOptionGroup<string | undefined>> = [
+    {
+      type: 'single',
+      option: { label: 'default', key: DEFAULT_PART_ID_KEY, value: undefined },
+    },
+    ...props.partIds.map<SelectOptionGroup<string>>((partId) => ({
+      type: 'single',
+      option: { label: partId, key: partId, value: partId },
+    })),
+  ];
+
+  const spanSelectOptionGroups: Array<SelectOptionGroup<vexml.CursorVerticalSpan>> = [
+    {
+      type: 'single',
+      option: { label: 'system', key: 'system', value: 'system' },
+    },
+    {
+      type: 'single',
+      option: { label: 'part', key: 'part', value: 'part' },
+    },
+  ];
+
+  const onAdd = () => {
+    const nextCursors = [cursor, ...cursors];
+    setCursors(nextCursors);
+    props.onChange(nextCursors);
+
+    const nextColorIndex = (COLORS.findIndex((color) => color === cursor.color) + 1) % COLORS.length;
+
+    const partIds = [undefined, ...props.partIds];
+    const nextPartIdIndex = (partIds.findIndex((partId) => partId === cursor.partId) + 1) % partIds.length;
+    const nextPartId = partIds[nextPartIdIndex];
+    setCursor({
+      type: 'discrete',
+      id: nextCursorId(),
+      color: COLORS[nextColorIndex],
+      partId: nextPartId,
+      span: 'system',
+    });
+  };
+
+  const onRemove = (id: string) => {
+    const nextCursors = [...cursors].filter((cursor) => cursor.id !== id);
+    setCursors(nextCursors);
+    props.onChange(nextCursors);
+  };
+
+  return (
+    <div>
+      <div className="row">
+        <div className="col d-flex align-items-center gap-2">
+          <div
+            className="border border-black"
+            style={{ backgroundColor: cursor.color, minWidth: 32, minHeight: 32, maxWidth: 32, maxHeight: 32 }}
+          ></div>
+          <Select
+            groups={colorSelectOptionGroups}
+            selectedKey={cursor.color}
+            onChange={(e) => {
+              setCursor((cursor) => ({ ...cursor, color: e.value }));
+            }}
+          />
+        </div>
+
+        <div className="col">
+          <Select
+            disabled
+            groups={cursorTypeSelectOptionGroups}
+            selectedKey={cursor.type}
+            onChange={(e) => {
+              setCursor((cursor) => ({ ...cursor, type: e.value }));
+            }}
+          />
+        </div>
+
+        <div className="col">
+          <Select
+            groups={partIdSelectOptionGroups}
+            selectedKey={cursor.partId ?? DEFAULT_PART_ID_KEY}
+            onChange={(e) => {
+              setCursor((cursor) => ({ ...cursor, partId: e.value }));
+            }}
+          />
+        </div>
+
+        <div className="col">
+          <Select
+            groups={spanSelectOptionGroups}
+            selectedKey={cursor.span}
+            onChange={(e) => {
+              setCursor((cursor) => ({ ...cursor, span: e.value }));
+            }}
+          />
+        </div>
+
+        <div className="col d-grid">
+          <button className="btn btn-outline-success" onClick={onAdd}>
+            Add
+          </button>
+        </div>
+      </div>
+
+      <hr />
+
+      <div className="d-grid gap-3">
+        {cursors.map((cursor) => (
+          <div className="row">
+            <div className="col d-flex align-items-center gap-2">
+              <div
+                className="border border-black"
+                style={{ backgroundColor: cursor.color, minWidth: 32, minHeight: 32, maxWidth: 32, maxHeight: 32 }}
+              ></div>
+              <Select disabled groups={colorSelectOptionGroups} selectedKey={cursor.color} />
+            </div>
+
+            <div className="col">
+              <Select disabled groups={cursorTypeSelectOptionGroups} selectedKey={cursor.type} />
+            </div>
+
+            <div className="col">
+              <Select disabled groups={partIdSelectOptionGroups} selectedKey={cursor.partId ?? DEFAULT_PART_ID_KEY} />
+            </div>
+
+            <div className="col">
+              <Select disabled groups={spanSelectOptionGroups} selectedKey={cursor.span} />
+            </div>
+
+            <div className="col d-grid">
+              <button className="btn btn-outline-danger" onClick={() => onRemove(cursor.id)}>
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/site/src/components/CursorForm.tsx
+++ b/site/src/components/CursorForm.tsx
@@ -19,7 +19,7 @@ export const CursorForm = (props: CursorFormProps) => {
     type: 'discrete',
     id: nextCursorId(),
     color: COLORS[0],
-    span: 'system',
+    span: 'part',
   }));
   const [cursors, setCursors] = useState(new Array<Cursor>());
 
@@ -63,11 +63,11 @@ export const CursorForm = (props: CursorFormProps) => {
   const spanSelectOptionGroups: Array<SelectOptionGroup<vexml.CursorVerticalSpan>> = [
     {
       type: 'single',
-      option: { label: 'system', key: 'system', value: 'system' },
+      option: { label: 'part', key: 'part', value: 'part' },
     },
     {
       type: 'single',
-      option: { label: 'part', key: 'part', value: 'part' },
+      option: { label: 'system', key: 'system', value: 'system' },
     },
   ];
 
@@ -86,7 +86,7 @@ export const CursorForm = (props: CursorFormProps) => {
       id: nextCursorId(),
       color: COLORS[nextColorIndex],
       partId: nextPartId,
-      span: 'system',
+      span: 'part',
     });
   };
 

--- a/site/src/components/CursorForm.tsx
+++ b/site/src/components/CursorForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Cursor } from '../types';
 import { Select, SelectOptionGroup } from './Select';
 import { useNextKey } from '../hooks/useNextKey';
@@ -22,6 +22,20 @@ export const CursorForm = (props: CursorFormProps) => {
     span: 'system',
   }));
   const [cursors, setCursors] = useState(new Array<Cursor>());
+
+  useEffect(() => {
+    const cursorPartIds = cursors
+      .map((cursor) => cursor.partId)
+      .filter((partId): partId is string => typeof partId === 'string');
+    if (cursorPartIds.some((partId) => !props.partIds.includes(partId))) {
+      const nextCursors = cursors.filter(
+        (cursor) => typeof cursor.partId !== 'string' || props.partIds.includes(cursor.partId)
+      );
+      setCursors(nextCursors);
+      props.onChange(nextCursors);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursors, props.partIds, props.onChange]);
 
   const colorSelectOptionGroups = COLORS.map<SelectOptionGroup<string>>((color) => ({
     type: 'single',

--- a/site/src/components/Select.tsx
+++ b/site/src/components/Select.tsx
@@ -1,7 +1,8 @@
 export type SelectProps<T> = {
+  disabled?: boolean;
   groups: SelectOptionGroup<T>[];
   selectedKey: string;
-  onChange: (event: SelectEvent<T>) => void;
+  onChange?: (event: SelectEvent<T>) => void;
 };
 
 type OptionGroupProps<T> = {
@@ -43,11 +44,11 @@ export function Select<T>(props: SelectProps<T>) {
     const value = props.groups
       .flatMap((group) => (group.type === 'multi' ? group.options : group.option))
       .find((option) => option.key === key)!.value;
-    props.onChange({ key, value });
+    props.onChange?.({ key, value });
   };
 
   return (
-    <select className="form-select" onChange={onChange} value={props.selectedKey}>
+    <select disabled={props.disabled} className="form-select" onChange={onChange} value={props.selectedKey}>
       {props.groups.map((group) =>
         group.type === 'multi' ? (
           <OptionGroup key={group.label} group={group} />

--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -110,10 +110,6 @@ export const SourceDisplay = (props: SourceProps) => {
   };
 
   const [partIds, setPartIds] = useState<string[]>([]);
-  const onPartIdsChange = (partIds: string[]) => {
-    setPartIds(partIds);
-  };
-
   const [cursors, setCursors] = useState(new Array<Cursor>());
   const onCursorsChange = (cursors: Cursor[]) => {
     setCursors(cursors);
@@ -272,7 +268,7 @@ export const SourceDisplay = (props: SourceProps) => {
               config={props.source.config}
               onResult={setVexmlResult}
               onEvent={onVexmlEvent}
-              onPartIdsChange={onPartIdsChange}
+              onPartIdsChange={setPartIds}
             />
           </div>
         )}

--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -1,7 +1,7 @@
 import * as vexml from '@/index';
 import { useCallback, useId, useRef, useState } from 'react';
 import { useMusicXML } from '../hooks/useMusicXML';
-import { RenderingBackend, Source } from '../types';
+import { Cursor, RenderingBackend, Source } from '../types';
 import { Vexml, VexmlResult } from './Vexml';
 import { useTooltip } from '../hooks/useTooltip';
 import { VEXML_VERSION } from '../constants';
@@ -107,6 +107,16 @@ export const SourceDisplay = (props: SourceProps) => {
   const vexmlModeName = useId();
   const onVexmlModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     props.onUpdate({ ...props.source, backend: e.target.value as RenderingBackend });
+  };
+
+  const [partIds, setPartIds] = useState<string[]>([]);
+  const onPartIdsChange = (partIds: string[]) => {
+    setPartIds(partIds);
+  };
+
+  const [cursors, setCursors] = useState(new Array<Cursor>());
+  const onCursorsChange = (cursors: Cursor[]) => {
+    setCursors(cursors);
   };
 
   return (
@@ -240,7 +250,7 @@ export const SourceDisplay = (props: SourceProps) => {
           <div id={cursorCardId} className="collapse mb-3" data-bs-parent={collapseRootSelector}>
             <h3 className="mb-3">Cursors</h3>
 
-            <CursorForm partIds={['foo', 'bar', 'baz']} onChange={() => {}} />
+            <CursorForm partIds={partIds} onChange={onCursorsChange} />
           </div>
         </div>
 
@@ -257,10 +267,12 @@ export const SourceDisplay = (props: SourceProps) => {
           <div className="d-flex justify-content-center">
             <Vexml
               musicXML={musicXML}
+              cursors={cursors}
               backend={props.source.backend}
               config={props.source.config}
               onResult={setVexmlResult}
               onEvent={onVexmlEvent}
+              onPartIdsChange={onPartIdsChange}
             />
           </div>
         )}

--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -14,6 +14,7 @@ import { EVENT_LOG_CAPACITY, EventLog, EventLogCard } from './EventLogCard';
 import { downloadCanvasAsImage } from '../util/downloadCanvasAsImage';
 import { ConfigForm } from './ConfigForm';
 import { EventTypeForm } from './EventTypeForm';
+import { CursorForm } from './CursorForm';
 
 const BUG_REPORT_HREF = `https://github.com/stringsync/vexml/issues/new?assignees=&labels=&projects=&template=bug-report.md&title=[BUG] (v${VEXML_VERSION}): <YOUR TITLE>`;
 const SNAPSHOT_NAME = `vexml_dev_${VEXML_VERSION.replace(/\./g, '_')}.png`;
@@ -98,6 +99,9 @@ export const SourceDisplay = (props: SourceProps) => {
     [enabledVexmlEventTypes, nextKey]
   );
 
+  const cursorCardId = useId();
+  const cursorCardSelector = '#' + cursorCardId.replaceAll(':', '\\:');
+
   const svgButtonId = useId();
   const canvasButtonId = useId();
   const vexmlModeName = useId();
@@ -138,6 +142,15 @@ export const SourceDisplay = (props: SourceProps) => {
               data-bs-target={configFormCardSelector}
             >
               <i className="bi bi-gear"></i> <p className="d-md-inline d-none">Config</p>
+            </button>
+
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              data-bs-toggle="collapse"
+              data-bs-target={cursorCardSelector}
+            >
+              <i className="bi bi-input-cursor"></i> <p className="d-md-inline d-none">Cursors</p>
             </button>
           </div>
 
@@ -222,6 +235,12 @@ export const SourceDisplay = (props: SourceProps) => {
             <h3 className="mb-3">Config</h3>
 
             <ConfigForm defaultValue={props.source.config} onChange={onConfigChange} />
+          </div>
+
+          <div id={cursorCardId} className="collapse mb-3" data-bs-parent={collapseRootSelector}>
+            <h3 className="mb-3">Cursors</h3>
+
+            <CursorForm partIds={['foo', 'bar', 'baz']} onChange={() => {}} />
           </div>
         </div>
 

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -2,7 +2,7 @@ import * as vexml from '@/index';
 import * as errors from '../util/errors';
 import { useEffect, useRef, useState } from 'react';
 import { useWidth } from '../hooks/useWidth';
-import { RenderingBackend } from '../types';
+import { Cursor, RenderingBackend } from '../types';
 
 const STRINGSYNC_RED = '#FC354C';
 
@@ -10,8 +10,10 @@ export type VexmlProps = {
   musicXML: string;
   backend: RenderingBackend;
   config: vexml.Config;
+  cursors: Cursor[];
   onResult: (result: VexmlResult) => void;
   onEvent: vexml.AnyEventListener;
+  onPartIdsChange: (partIds: string[]) => void;
 };
 
 export type VexmlResult =
@@ -156,6 +158,9 @@ export const Vexml = (props: VexmlProps) => {
         config,
       });
       setRendering(rendering);
+
+      const partIds = rendering.getPartIds();
+      props.onPartIdsChange(partIds);
 
       const element = rendering.getVexflowElement();
       // For screenshots, we want the background to be white.

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -40,6 +40,18 @@ export const Vexml = ({ musicXML, backend, config, cursors, onResult, onEvent, o
     }
   };
 
+  const onPreviousClick = () => {
+    for (const discreteCursor of discreteCursors) {
+      discreteCursor.previous();
+    }
+  };
+
+  const onNextClick = () => {
+    for (const discreteCursor of discreteCursors) {
+      discreteCursor.next();
+    }
+  };
+
   useEffect(() => {
     if (!rendering) {
       return;
@@ -198,21 +210,50 @@ export const Vexml = ({ musicXML, backend, config, cursors, onResult, onEvent, o
   return (
     <div className="w-100">
       <div ref={divRef}></div>
-      <div className="d-flex align-items-center gap-3 m-3">
-        <button className="btn bg-transparent" style={{ fontSize: 24 }}>
-          <i className="bi bi-play-fill"></i>
-        </button>
-        <input
-          className="w-100 form-range"
-          type="range"
-          min={0}
-          max={1}
-          step={0.01}
-          value={progress}
-          onChange={onProgressChange}
-        ></input>
-        <span>0:00</span>
-      </div>
+
+      {discreteCursors.length > 0 && (
+        <>
+          <div className="alert alert-warning d-flex align-items-center" role="alert">
+            <i className="bi bi-exclamation-triangle-fill me-2"></i>
+            <div>The controls are a work in progress.</div>
+          </div>
+
+          <div>
+            <div className="d-flex align-items-center gap-3 mt-3">
+              <span>0:00</span>
+              <input
+                className="w-100 form-range"
+                type="range"
+                min={0}
+                max={1}
+                step={0.01}
+                value={progress}
+                onChange={onProgressChange}
+              ></input>
+              <span>0:00</span>
+            </div>
+            <div className="d-flex gap-2 justify-content-center mt-2">
+              <button
+                className="btn btn-outline-primary border border-0"
+                style={{ fontSize: 20 }}
+                onClick={onPreviousClick}
+              >
+                <i className="bi bi-chevron-bar-left"></i>
+              </button>
+              <button className="btn btn-outline-primary rounded-circle" style={{ fontSize: 24 }}>
+                <i className="bi bi-play-fill"></i>
+              </button>
+              <button
+                className="btn btn-outline-primary border border-0"
+                style={{ fontSize: 20 }}
+                onClick={onNextClick}
+              >
+                <i className="bi bi-chevron-bar-right"></i>
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -29,3 +29,12 @@ export type Keyed<T> = {
 
 /** The modes for rendering vexml. */
 export type RenderingBackend = 'svg' | 'canvas';
+
+/** Cursors that assist with navigating the rendered notation. */
+export type Cursor = {
+  type: 'discrete';
+  id: string;
+  color: string;
+  span: vexml.CursorVerticalSpan;
+  partId?: string;
+};

--- a/src/components/cursor.ts
+++ b/src/components/cursor.ts
@@ -1,3 +1,5 @@
+const STRINGSYNC_RED = '#FC354C';
+
 export class Cursor {
   private element: HTMLElement;
 
@@ -5,12 +7,12 @@ export class Cursor {
     this.element = element;
   }
 
-  static render(parent: HTMLElement) {
+  static render(parent: HTMLElement, color = STRINGSYNC_RED) {
     const element = document.createElement('div');
     element.classList.add('vexml-cursor');
     element.style.width = '1.5px';
     element.style.position = 'absolute';
-    element.style.backgroundColor = 'red';
+    element.style.backgroundColor = color;
 
     parent.append(element);
 

--- a/src/cursors/discretecursor.ts
+++ b/src/cursors/discretecursor.ts
@@ -1,9 +1,8 @@
-import * as playback from '@/playback';
 import * as events from '@/events';
-import * as util from '@/util';
+import * as playback from '@/playback';
 import * as spatial from '@/spatial';
 
-const CURSOR_WIDTH_PX = 1.5;
+// const CURSOR_WIDTH_PX = 1.5;
 
 type EventMap = {
   change: CursorState;
@@ -38,20 +37,7 @@ export class DiscreteCursor {
       };
     }
 
-    const systemBoundingBoxes = [
-      ...entry.system.staveInteractions.map((staveInteraction) => staveInteraction.getBoundingBox()),
-      ...entry.system.playableInteractions.map((playableInteraction) => playableInteraction.getBoundingBox()),
-    ];
-    const minY = util.min(
-      systemBoundingBoxes.map((box) => box.getMinY()),
-      Number.POSITIVE_INFINITY
-    );
-    const maxY = util.max(
-      systemBoundingBoxes.map((box) => box.getMaxY()),
-      Number.NEGATIVE_INFINITY
-    );
-
-    if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+    if (entry.playables.length === 0) {
       return {
         index: this.index,
         length: this.sequence.getLength(),
@@ -59,14 +45,41 @@ export class DiscreteCursor {
       };
     }
 
-    const playableBoundingBox = entry.playableInteraction.getBoundingBox();
-    const leftX = playableBoundingBox.getMinX();
-    const rightX = playableBoundingBox.getMaxX();
+    // TODO: Fix this to adhere to the new model.
+    // const systemBoundingBoxes: spatial.Rect[] = [
+    //   ...entry.system.staveInteractions.map((staveInteraction) => staveInteraction.getBoundingBox()),
+    //   ...entry.system.playableInteractions.map((playableInteraction) => playableInteraction.getBoundingBox()),
+    // ];
+    // const minY = util.min(
+    //   systemBoundingBoxes.map((box) => box.getMinY()),
+    //   Number.POSITIVE_INFINITY
+    // );
+    // const maxY = util.max(
+    //   systemBoundingBoxes.map((box) => box.getMaxY()),
+    //   Number.NEGATIVE_INFINITY
+    // );
 
-    const x = (leftX + rightX) / 2;
-    const y = minY;
-    const w = CURSOR_WIDTH_PX;
-    const h = maxY - minY;
+    // if (!Number.isFinite(minY) || !Number.isFinite(maxY)) {
+    //   return {
+    //     index: this.index,
+    //     length: this.sequence.getLength(),
+    //     rect: null,
+    //   };
+    // }
+
+    // const playableBoundingBox = entry.playables[0].getBoundingBox();
+    // const leftX = playableBoundingBox.getMinX();
+    // const rightX = playableBoundingBox.getMaxX();
+
+    // const x = (leftX + rightX) / 2;
+    // const y = minY;
+    // const w = CURSOR_WIDTH_PX;
+    // const h = maxY - minY;
+
+    const x = 0;
+    const y = 0;
+    const w = 0;
+    const h = 0;
 
     return {
       index: this.index,

--- a/src/cursors/discretecursor.ts
+++ b/src/cursors/discretecursor.ts
@@ -66,7 +66,9 @@ export class DiscreteCursor {
       };
     }
 
-    const systemIndex = entry.interactables[0].address.getSystemIndex()!;
+    const systemIndex = entry.interactables[0].address.getSystemIndex();
+    util.assertDefined(systemIndex);
+
     const systemRect = this.getVerticalSpanRect(systemIndex);
     const playableRect = rendering.InteractionModel.create(entry.interactables[0]).getBoundingBox();
 

--- a/src/cursors/types.ts
+++ b/src/cursors/types.ts
@@ -1,0 +1,1 @@
+export type CursorVerticalSpan = 'system' | 'part';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './rendering/events';
 export type { Rendering, CursorVerticalSpan } from './rendering';
 export { CONFIG_SCHEMA, DEFAULT_CONFIG } from './config';
 export type { Config, SchemaDescriptor, SchemaType, SchemaConfig } from './config';
+export type { DiscreteCursor } from './cursors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './vexml';
 export * from './rendering/events';
-export type { Rendering } from './rendering';
+export type { Rendering, CursorVerticalSpan } from './rendering';
 export { CONFIG_SCHEMA, DEFAULT_CONFIG } from './config';
 export type { Config, SchemaDescriptor, SchemaType, SchemaConfig } from './config';

--- a/src/playback/sequence.ts
+++ b/src/playback/sequence.ts
@@ -72,28 +72,24 @@ export class Sequence {
       const playables = new Array<PlayableRendering>();
       const entries = new Array<SequenceEntry>();
       let tick = 0;
-      for (let index = 0; index < events.length; index++) {
-        const event = events[index];
-
-        if (event.type === 'start') {
-          playables.push(event.playable);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      util.forEachTriple(events, ([_, currentEvent, nextEvent]) => {
+        if (currentEvent.type === 'start') {
+          playables.push(currentEvent.playable);
         }
 
-        if (event.type === 'stop') {
-          playables.splice(playables.indexOf(event.playable), 1);
+        if (currentEvent.type === 'stop') {
+          playables.splice(playables.indexOf(currentEvent.playable), 1);
         }
 
-        // If this is the last event or the next event is at a different tick, create a new entry.
-        if (index === events.length - 1 || events[index + 1].tick !== tick) {
+        if (nextEvent && tick !== nextEvent.tick) {
           const startTick = tick;
-          // TODO: Fix this for tick === 0.
-          const stopTick = tick + event.tick;
+          const stopTick = nextEvent.tick;
           const tickRange = new util.NumberRange(startTick, stopTick);
           tick = stopTick;
-
           entries.push({ playables: [...playables], tickRange });
         }
-      }
+      });
 
       return new Sequence(partId, entries);
     });

--- a/src/playback/sequence.ts
+++ b/src/playback/sequence.ts
@@ -79,7 +79,7 @@ export class Sequence {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       util.forEachTriple(events, ([previousEvent, currentEvent, nextEvent]) => {
         if (currentEvent.type === 'start') {
-          interactables.push(currentEvent.interactable);
+          interactables.unshift(currentEvent.interactable);
         }
 
         if (currentEvent.type === 'stop') {

--- a/src/playback/sequence.ts
+++ b/src/playback/sequence.ts
@@ -138,5 +138,5 @@ function getTicks(playable: PlayableRendering): number {
 }
 
 function isInteractable(value: any): value is rendering.InteractableRendering {
-  return PLAYABLE_RENDERING_TYPES.includes(value.type);
+  return rendering.INTERACTABLE_RENDERING_TYPES.includes(value.type);
 }

--- a/src/playback/sequence.ts
+++ b/src/playback/sequence.ts
@@ -73,7 +73,7 @@ export class Sequence {
       const entries = new Array<SequenceEntry>();
       let tick = 0;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      util.forEachTriple(events, ([_, currentEvent, nextEvent]) => {
+      util.forEachTriple(events, ([previousEvent, currentEvent, nextEvent]) => {
         if (currentEvent.type === 'start') {
           playables.push(currentEvent.playable);
         }

--- a/src/rendering/address.ts
+++ b/src/rendering/address.ts
@@ -17,7 +17,7 @@ export type AddressContext<T extends AddressType> = T extends 'system'
   : T extends 'chorus'
   ? Record<never, never>
   : T extends 'voice'
-  ? { voiceIndex: number }
+  ? { voiceId: string }
   : never;
 
 /** The location of a musical object in the rendering hierarchy. */
@@ -91,11 +91,11 @@ export class Address<T extends AddressType = AddressType> {
     return staveAddress.context?.staveNumber;
   }
 
-  /** Returns the voice number. */
-  getVoiceNumber(): number | undefined {
+  /** Returns the voice ID. */
+  getVoiceId(): string | undefined {
     const voiceAddress = this.getAddress('voice');
     util.assertNotNull(voiceAddress);
-    return voiceAddress.context?.voiceIndex;
+    return voiceAddress.context?.voiceId;
   }
 
   /** Creates an address for a measure. */

--- a/src/rendering/chorus.ts
+++ b/src/rendering/chorus.ts
@@ -52,9 +52,9 @@ export class Chorus {
 
     if (this.voices.length > 0) {
       const vfVoices = this.voices.map(
-        (voice, index) =>
+        (voice) =>
           voice.render({
-            address: address.voice({ voiceIndex: index }),
+            address: address.voice({ voiceId: voice.getId() }),
             spanners,
           }).vexflow.voice
       );
@@ -68,9 +68,9 @@ export class Chorus {
 
   /** Renders the chorus. */
   render(opts: { address: Address<'chorus'>; spanners: Spanners }): ChorusRendering {
-    const voiceRenderings = this.voices.map((voice, index) =>
+    const voiceRenderings = this.voices.map((voice) =>
       voice.render({
-        address: opts.address.voice({ voiceIndex: index }),
+        address: opts.address.voice({ voiceId: voice.getId() }),
         spanners: opts.spanners,
       })
     );

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -13,3 +13,4 @@ export * from './multirest';
 export * from './part';
 export * from './interactions';
 export * from './query';
+export * from './ghostnote';

--- a/src/rendering/interactions.ts
+++ b/src/rendering/interactions.ts
@@ -3,11 +3,11 @@ import * as util from '@/util';
 import { StaveChordRendering, TabChordRendering } from './chord';
 import { MeasureRendering } from './measure';
 import { StaveNoteRendering, TabNoteRendering } from './note';
-import { SelectableRenderingWithType } from './query';
+import { Query, SelectableRenderingWithType } from './query';
 import { RestRendering } from './rest';
 import { StaveRendering } from './stave';
 
-export const INTERACTABLE_RENDERING_TYPES = [
+const INTERACTABLE_RENDERING_TYPES = [
   'measure',
   'stavenote',
   'stavechord',
@@ -35,8 +35,12 @@ export class InteractionModel<T> {
     this.value = value;
   }
 
-  static create<T extends InteractableRendering>(renderings: T[]): InteractionModel<T>[] {
-    return InteractionModelFactory.create(renderings) as InteractionModel<T>[];
+  static create<T extends InteractableRendering>(rendering: T): InteractionModel<T> {
+    return InteractionModelFactory.create(rendering) as InteractionModel<T>;
+  }
+
+  static fromQuery(query: Query) {
+    return InteractionModelFactory.fromQuery(query);
   }
 
   /** Returns a box that contains all the handles. */
@@ -127,25 +131,29 @@ export class InteractionHandle {
 }
 
 class InteractionModelFactory {
-  static create<T extends InteractableRendering>(renderings: T[]) {
-    return renderings.map((rendering) => {
-      switch (rendering.type) {
-        case 'measure':
-          return InteractionModelFactory.fromMeasureRendering(rendering);
-        case 'stavenote':
-          return InteractionModelFactory.fromStaveNoteRendering(rendering);
-        case 'stavechord':
-          return InteractionModelFactory.fromStaveChordRendering(rendering);
-        case 'rest':
-          return InteractionModelFactory.fromRestRendering(rendering);
-        case 'tabnote':
-          return InteractionModelFactory.fromTabNoteRendering(rendering);
-        case 'tabchord':
-          return InteractionModelFactory.fromTabChordRendering(rendering);
-        case 'stave':
-          return InteractionModelFactory.fromStaveRendering(rendering);
-      }
-    });
+  static create(rendering: InteractableRendering) {
+    switch (rendering.type) {
+      case 'measure':
+        return InteractionModelFactory.fromMeasureRendering(rendering);
+      case 'stavenote':
+        return InteractionModelFactory.fromStaveNoteRendering(rendering);
+      case 'stavechord':
+        return InteractionModelFactory.fromStaveChordRendering(rendering);
+      case 'rest':
+        return InteractionModelFactory.fromRestRendering(rendering);
+      case 'tabnote':
+        return InteractionModelFactory.fromTabNoteRendering(rendering);
+      case 'tabchord':
+        return InteractionModelFactory.fromTabChordRendering(rendering);
+      case 'stave':
+        return InteractionModelFactory.fromStaveRendering(rendering);
+      default:
+        throw new Error(`unsupported rendering type: ${rendering.type}`);
+    }
+  }
+
+  static fromQuery(query: Query) {
+    return query.select(...INTERACTABLE_RENDERING_TYPES).flatMap(InteractionModelFactory.create);
   }
 
   private static fromMeasureRendering(measure: MeasureRendering): InteractionModel<MeasureRendering> {

--- a/src/rendering/interactions.ts
+++ b/src/rendering/interactions.ts
@@ -7,7 +7,7 @@ import { Query, SelectableRenderingWithType } from './query';
 import { RestRendering } from './rest';
 import { StaveRendering } from './stave';
 
-const INTERACTABLE_RENDERING_TYPES = [
+export const INTERACTABLE_RENDERING_TYPES = [
   'measure',
   'stavenote',
   'stavechord',

--- a/src/rendering/interactions.ts
+++ b/src/rendering/interactions.ts
@@ -1,11 +1,27 @@
 import * as spatial from '@/spatial';
 import * as util from '@/util';
-import { StaveNoteRendering, TabNoteRendering } from './note';
 import { StaveChordRendering, TabChordRendering } from './chord';
-import { RestRendering } from './rest';
 import { MeasureRendering } from './measure';
-import { InteractableRendering } from './query';
+import { StaveNoteRendering, TabNoteRendering } from './note';
+import { SelectableRenderingWithType } from './query';
+import { RestRendering } from './rest';
 import { StaveRendering } from './stave';
+
+export const INTERACTABLE_RENDERING_TYPES = [
+  'measure',
+  'stavenote',
+  'stavechord',
+  'gracenote',
+  'gracechord',
+  'tabnote',
+  'tabchord',
+  'tabgracenote',
+  'tabgracechord',
+  'rest',
+  'stave',
+] as const;
+
+export type InteractableRendering = SelectableRenderingWithType<(typeof INTERACTABLE_RENDERING_TYPES)[number]>;
 
 export type InteractionModelType = InteractionModel<InteractableRendering>;
 
@@ -128,8 +144,6 @@ class InteractionModelFactory {
           return InteractionModelFactory.fromTabChordRendering(rendering);
         case 'stave':
           return InteractionModelFactory.fromStaveRendering(rendering);
-        default:
-          throw new Error(`unsupported rendering: ${rendering}`);
       }
     });
   }

--- a/src/rendering/locator.ts
+++ b/src/rendering/locator.ts
@@ -2,7 +2,7 @@ import * as spatial from '@/spatial';
 import * as vexflow from 'vexflow';
 import * as drawables from '@/drawables';
 import { ScoreRendering } from './score';
-import { InteractionModel, InteractionModelType } from './interactions';
+import { INTERACTABLE_RENDERING_TYPES, InteractionModel, InteractionModelType } from './interactions';
 import { Query } from './query';
 
 /**
@@ -27,7 +27,7 @@ export class Locator implements spatial.PointLocator<InteractionModelType> {
   static fromScoreRendering(score: ScoreRendering): Locator {
     const targets = new Array<InteractionModelType>();
 
-    const interactables = Query.of(score).getInteractables();
+    const interactables = Query.of(score).select(...INTERACTABLE_RENDERING_TYPES);
     const models = InteractionModel.create(interactables);
 
     // First attempt to insert all the shapes into the tree.

--- a/src/rendering/locator.ts
+++ b/src/rendering/locator.ts
@@ -27,7 +27,7 @@ export class Locator implements spatial.PointLocator<InteractionModelType> {
   static fromScoreRendering(score: ScoreRendering): Locator {
     const targets = new Array<InteractionModelType>();
 
-    const interactables = Query.of(score).interactables();
+    const interactables = Query.of(score).getInteractables();
     const models = InteractionModel.create(interactables);
 
     // First attempt to insert all the shapes into the tree.

--- a/src/rendering/locator.ts
+++ b/src/rendering/locator.ts
@@ -2,7 +2,7 @@ import * as spatial from '@/spatial';
 import * as vexflow from 'vexflow';
 import * as drawables from '@/drawables';
 import { ScoreRendering } from './score';
-import { INTERACTABLE_RENDERING_TYPES, InteractionModel, InteractionModelType } from './interactions';
+import { InteractionModel, InteractionModelType } from './interactions';
 import { Query } from './query';
 
 /**
@@ -27,8 +27,7 @@ export class Locator implements spatial.PointLocator<InteractionModelType> {
   static fromScoreRendering(score: ScoreRendering): Locator {
     const targets = new Array<InteractionModelType>();
 
-    const interactables = Query.of(score).select(...INTERACTABLE_RENDERING_TYPES);
-    const models = InteractionModel.create(interactables);
+    const models = InteractionModel.fromQuery(Query.of(score));
 
     // First attempt to insert all the shapes into the tree.
     const tree = new spatial.QuadTree<InteractionModelType>(score.boundary, QUAD_TREE_THRESHOLD);

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -7,6 +7,8 @@ import { EventMap } from './events';
 import { Config } from '@/config';
 import { ScoreRendering } from './score';
 
+const STRINGSYNC_RED = '#FC354C';
+
 /** Describes how much the cursor should vertically span. */
 export type CursorVerticalSpan = 'system' | 'part';
 
@@ -46,7 +48,7 @@ export class Rendering {
   }
 
   /** Creates a new discrete cursor for the part ID */
-  createDiscreteCursor(opts?: { span?: CursorVerticalSpan; partId?: string }): cursors.DiscreteCursor {
+  createDiscreteCursor(opts?: { span?: CursorVerticalSpan; partId?: string; color?: string }): cursors.DiscreteCursor {
     const span = opts?.span ?? 'system';
     const partId = opts?.partId ?? this.partIds[0];
 
@@ -56,7 +58,7 @@ export class Rendering {
 
     const overlayElement = this.root.getOverlay().getElement();
     const cursorModel = new cursors.DiscreteCursor(this.score, sequence, span);
-    const cursorComponent = components.Cursor.render(overlayElement);
+    const cursorComponent = components.Cursor.render(overlayElement, opts?.color);
 
     cursorModel.addEventListener('change', (event) => {
       const rect = event.rect;

--- a/src/rendering/voice.ts
+++ b/src/rendering/voice.ts
@@ -25,6 +25,7 @@ const DURATIONS_SHORTER_THAN_QUARTER_NOTE = ['1024', '512', '256', '128', '64', 
 /** The result of rendering a voice. */
 export type VoiceRendering = {
   type: 'voice';
+  id: string;
   address: Address<'voice'>;
   vexflow: {
     voice: vexflow.Voice;
@@ -282,6 +283,7 @@ export class Voice {
 
     return {
       type: 'voice',
+      id: this.id,
       address,
       vexflow: {
         voice: vfVoice,

--- a/src/rendering/voice.ts
+++ b/src/rendering/voice.ts
@@ -209,6 +209,11 @@ export class Voice {
     }
   }
 
+  /** Returns the voice ID. */
+  getId(): string {
+    return this.id;
+  }
+
   /** Renders the voice. */
   render(opts: { address: Address<'voice'>; spanners: Spanners }): VoiceRendering {
     const address = opts.address;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -9,3 +9,4 @@ export * from './fraction';
 export * from './assert';
 export * from './lru';
 export * from './device';
+export * from './numberrange';

--- a/src/util/numberrange.ts
+++ b/src/util/numberrange.ts
@@ -1,97 +1,34 @@
 export class NumberRange {
-  private left: Bound;
-  private right: Bound;
+  private left: number;
+  private right: number;
 
-  constructor(left: Bound, right: Bound) {
-    if (left.value > right.value) {
+  constructor(left: number, right: number) {
+    if (left > right) {
       throw new Error('Invalid range: left bound must be less than or equal to right bound.');
     }
     this.left = left;
     this.right = right;
   }
 
-  static fromInclusive(left: number): PartialNumberRange {
-    return new PartialNumberRange(Bound.inclusive(left));
-  }
-
-  static fromExclusive(left: number): PartialNumberRange {
-    return new PartialNumberRange(Bound.exclusive(left));
-  }
-
   getLeft(): number {
-    return this.left.value;
+    return this.left;
   }
 
   getRight(): number {
-    return this.right.value;
+    return this.right;
   }
 
-  contains(value: number): boolean {
-    let leftCheck: boolean;
-    switch (this.left.type) {
-      case 'inclusive':
-        leftCheck = value >= this.left.value;
-        break;
-      case 'exclusive':
-        leftCheck = value > this.left.value;
-        break;
-    }
+  includes(value: number): boolean {
+    return value >= this.left && value <= this.right;
+  }
 
-    let rightCheck: boolean;
-    switch (this.right.type) {
-      case 'inclusive':
-        rightCheck = value <= this.right.value;
-        break;
-      case 'exclusive':
-        rightCheck = value < this.right.value;
-        break;
-    }
-
-    return leftCheck && rightCheck;
+  contains(range: NumberRange): boolean {
+    return this.includes(range.left) && this.includes(range.right);
   }
 
   overlaps(range: NumberRange): boolean {
     return (
-      this.contains(range.left.value) ||
-      this.contains(range.right.value) ||
-      range.contains(this.left.value) ||
-      range.contains(this.right.value)
+      this.includes(range.left) || this.includes(range.right) || range.includes(this.left) || range.includes(this.right)
     );
-  }
-}
-
-class PartialNumberRange {
-  private left: Bound;
-
-  constructor(left: Bound) {
-    this.left = left;
-  }
-
-  toInclusive(right: number): NumberRange {
-    return new NumberRange(this.left, Bound.inclusive(right));
-  }
-
-  toExclusive(right: number): NumberRange {
-    return new NumberRange(this.left, Bound.exclusive(right));
-  }
-}
-
-type BoundType = 'inclusive' | 'exclusive';
-
-class Bound {
-  public readonly value: number;
-  public readonly type: BoundType;
-
-  private constructor(value: number, type: BoundType) {
-    this.value = value;
-    this.type = type;
-  }
-
-  static inclusive(value: number): Bound {
-    return new Bound(value, 'inclusive');
-  }
-
-  static exclusive(value: number): Bound {
-    return new Bound(value, 'exclusive');
   }
 }

--- a/src/util/numberrange.ts
+++ b/src/util/numberrange.ts
@@ -1,0 +1,97 @@
+export class NumberRange {
+  private left: Bound;
+  private right: Bound;
+
+  constructor(left: Bound, right: Bound) {
+    if (left.value > right.value) {
+      throw new Error('Invalid range: left bound must be less than or equal to right bound.');
+    }
+    this.left = left;
+    this.right = right;
+  }
+
+  static fromInclusive(left: number): PartialNumberRange {
+    return new PartialNumberRange(Bound.inclusive(left));
+  }
+
+  static fromExclusive(left: number): PartialNumberRange {
+    return new PartialNumberRange(Bound.exclusive(left));
+  }
+
+  getLeft(): number {
+    return this.left.value;
+  }
+
+  getRight(): number {
+    return this.right.value;
+  }
+
+  contains(value: number): boolean {
+    let leftCheck: boolean;
+    switch (this.left.type) {
+      case 'inclusive':
+        leftCheck = value >= this.left.value;
+        break;
+      case 'exclusive':
+        leftCheck = value > this.left.value;
+        break;
+    }
+
+    let rightCheck: boolean;
+    switch (this.right.type) {
+      case 'inclusive':
+        rightCheck = value <= this.right.value;
+        break;
+      case 'exclusive':
+        rightCheck = value < this.right.value;
+        break;
+    }
+
+    return leftCheck && rightCheck;
+  }
+
+  overlaps(range: NumberRange): boolean {
+    return (
+      this.contains(range.left.value) ||
+      this.contains(range.right.value) ||
+      range.contains(this.left.value) ||
+      range.contains(this.right.value)
+    );
+  }
+}
+
+class PartialNumberRange {
+  private left: Bound;
+
+  constructor(left: Bound) {
+    this.left = left;
+  }
+
+  toInclusive(right: number): NumberRange {
+    return new NumberRange(this.left, Bound.inclusive(right));
+  }
+
+  toExclusive(right: number): NumberRange {
+    return new NumberRange(this.left, Bound.exclusive(right));
+  }
+}
+
+type BoundType = 'inclusive' | 'exclusive';
+
+class Bound {
+  public readonly value: number;
+  public readonly type: BoundType;
+
+  private constructor(value: number, type: BoundType) {
+    this.value = value;
+    this.type = type;
+  }
+
+  static inclusive(value: number): Bound {
+    return new Bound(value, 'inclusive');
+  }
+
+  static exclusive(value: number): Bound {
+    return new Bound(value, 'exclusive');
+  }
+}

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -133,6 +133,7 @@ export class Vexml {
 
     return new rendering.Rendering({
       config,
+      score: scoreRendering,
       topic: vexmlEventTopic,
       bridge,
       root,

--- a/tests/unit/util/numberrange.test.ts
+++ b/tests/unit/util/numberrange.test.ts
@@ -1,62 +1,42 @@
 import { NumberRange } from '@/util/numberrange';
 
 describe(NumberRange, () => {
-  it('should create a valid range with inclusive bounds', () => {
-    const range = NumberRange.fromInclusive(1).toInclusive(5);
-    expect(range.getLeft()).toBe(1);
-    expect(range.getRight()).toBe(5);
-  });
+  describe(NumberRange, () => {
+    test('should create a valid NumberRange', () => {
+      const range = new NumberRange(1, 5);
+      expect(range.getLeft()).toBe(1);
+      expect(range.getRight()).toBe(5);
+    });
 
-  it('should create a valid range with exclusive bounds', () => {
-    const range = NumberRange.fromExclusive(1).toExclusive(5);
-    expect(range.getLeft()).toBe(1);
-    expect(range.getRight()).toBe(5);
-  });
+    test('should throw an error for invalid range', () => {
+      expect(() => new NumberRange(5, 1)).toThrow(
+        'Invalid range: left bound must be less than or equal to right bound.'
+      );
+    });
 
-  it('should throw an error if left bound is greater than right bound', () => {
-    expect(() => {
-      NumberRange.fromInclusive(5).toInclusive(1);
-    }).toThrow('Invalid range: left bound must be less than or equal to right bound.');
-  });
+    test('should include a value within the range', () => {
+      const range = new NumberRange(1, 5);
+      expect(range.includes(3)).toBe(true);
+      expect(range.includes(1)).toBe(true);
+      expect(range.includes(5)).toBe(true);
+      expect(range.includes(0)).toBe(false);
+      expect(range.includes(6)).toBe(false);
+    });
 
-  it('should check if a value is within the range', () => {
-    const range = NumberRange.fromInclusive(1).toInclusive(5);
-    expect(range.contains(3)).toBeTrue();
-    expect(range.contains(0)).toBeFalse();
-  });
+    test('should contain another range within itself', () => {
+      const range1 = new NumberRange(1, 5);
+      const range2 = new NumberRange(2, 4);
+      const range3 = new NumberRange(0, 6);
+      expect(range1.contains(range2)).toBe(true);
+      expect(range1.contains(range3)).toBe(false);
+    });
 
-  it('should check if two ranges overlap', () => {
-    const range1 = NumberRange.fromInclusive(1).toInclusive(5);
-    const range2 = NumberRange.fromInclusive(4).toInclusive(6);
-    const range3 = NumberRange.fromInclusive(6).toInclusive(8);
-
-    expect(range1.overlaps(range2)).toBeTrue();
-    expect(range1.overlaps(range3)).toBeFalse();
-  });
-
-  it('should correctly handle inclusive left and exclusive right bounds', () => {
-    const range = NumberRange.fromInclusive(1).toExclusive(5);
-    expect(range.contains(1)).toBeTrue();
-    expect(range.contains(5)).toBeFalse();
-  });
-
-  it('should correctly handle exclusive left and inclusive right bounds', () => {
-    const range = NumberRange.fromExclusive(1).toInclusive(5);
-    expect(range.contains(1)).toBeFalse();
-    expect(range.contains(5)).toBeTrue();
-  });
-
-  it('should correctly handle exclusive bounds', () => {
-    const range = NumberRange.fromExclusive(1).toExclusive(5);
-    expect(range.contains(1)).toBeFalse();
-    expect(range.contains(5)).toBeFalse();
-    expect(range.contains(3)).toBeTrue();
-  });
-
-  it('should correctly handle inclusive bounds', () => {
-    const range = NumberRange.fromInclusive(1).toInclusive(5);
-    expect(range.contains(1)).toBeTrue();
-    expect(range.contains(5)).toBeTrue();
-    expect(range.contains(3)).toBeTrue();
+    test('should overlap with another range', () => {
+      const range1 = new NumberRange(1, 5);
+      const range2 = new NumberRange(4, 6);
+      const range3 = new NumberRange(6, 8);
+      expect(range1.overlaps(range2)).toBe(true);
+      expect(range1.overlaps(range3)).toBe(false);
+    });
   });
 });

--- a/tests/unit/util/numberrange.test.ts
+++ b/tests/unit/util/numberrange.test.ts
@@ -1,0 +1,62 @@
+import { NumberRange } from '@/util/numberrange';
+
+describe(NumberRange, () => {
+  it('should create a valid range with inclusive bounds', () => {
+    const range = NumberRange.fromInclusive(1).toInclusive(5);
+    expect(range.getLeft()).toBe(1);
+    expect(range.getRight()).toBe(5);
+  });
+
+  it('should create a valid range with exclusive bounds', () => {
+    const range = NumberRange.fromExclusive(1).toExclusive(5);
+    expect(range.getLeft()).toBe(1);
+    expect(range.getRight()).toBe(5);
+  });
+
+  it('should throw an error if left bound is greater than right bound', () => {
+    expect(() => {
+      NumberRange.fromInclusive(5).toInclusive(1);
+    }).toThrow('Invalid range: left bound must be less than or equal to right bound.');
+  });
+
+  it('should check if a value is within the range', () => {
+    const range = NumberRange.fromInclusive(1).toInclusive(5);
+    expect(range.contains(3)).toBeTrue();
+    expect(range.contains(0)).toBeFalse();
+  });
+
+  it('should check if two ranges overlap', () => {
+    const range1 = NumberRange.fromInclusive(1).toInclusive(5);
+    const range2 = NumberRange.fromInclusive(4).toInclusive(6);
+    const range3 = NumberRange.fromInclusive(6).toInclusive(8);
+
+    expect(range1.overlaps(range2)).toBeTrue();
+    expect(range1.overlaps(range3)).toBeFalse();
+  });
+
+  it('should correctly handle inclusive left and exclusive right bounds', () => {
+    const range = NumberRange.fromInclusive(1).toExclusive(5);
+    expect(range.contains(1)).toBeTrue();
+    expect(range.contains(5)).toBeFalse();
+  });
+
+  it('should correctly handle exclusive left and inclusive right bounds', () => {
+    const range = NumberRange.fromExclusive(1).toInclusive(5);
+    expect(range.contains(1)).toBeFalse();
+    expect(range.contains(5)).toBeTrue();
+  });
+
+  it('should correctly handle exclusive bounds', () => {
+    const range = NumberRange.fromExclusive(1).toExclusive(5);
+    expect(range.contains(1)).toBeFalse();
+    expect(range.contains(5)).toBeFalse();
+    expect(range.contains(3)).toBeTrue();
+  });
+
+  it('should correctly handle inclusive bounds', () => {
+    const range = NumberRange.fromInclusive(1).toInclusive(5);
+    expect(range.contains(1)).toBeTrue();
+    expect(range.contains(5)).toBeTrue();
+    expect(range.contains(3)).toBeTrue();
+  });
+});


### PR DESCRIPTION
This PR adds `DiscreteCursor` controls to the site.

https://github.com/user-attachments/assets/10deb5e5-3eb9-4888-ba99-57e6d675aa89

`DiscreteCursor` objects are instantiated on a per-part basis because part components may diverge in positioning, particularly in orchestral music. By default, a `DiscreteCursor` will be made for the first part and span the entire system, but they can be configured to span just the part.

The things I'm working on next:

- Abstract a cursor _component_ interface that allows the caller to control the rendering of the cursor (not the model). vexml will provide some default implementations. Probably `NoopDiscreteCursor` and `SimpleDiscreteCursor`. The `SimpleDiscreteCursor` needs to specify whether to render on the left edge, center, or right edge of the `Rect` prescribed by the cursor model.
- Make the `DiscreteCursor` model seekable. Given a tick number, the cursor should move to the index that corresponds to it.
- Expose the current active interactables and the tick range in `CursorState`. The tick range should be used to improve the UX in the site. When clicking previous and next, the cursors should just seek to the _closest_ previous or next time of all present cursors.
- Make the `Sequence` BPM-aware. This BPM needs to be used when converting time to tick ranges. `Sequence` should also probably expose the duration. Once all of this is done, I can make the play/pause button on the site work.