### PR TITLE
Implement smooth interpolated seeking

### DIFF
--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -42,7 +42,7 @@ export const Vexml = ({ musicXML, backend, config, cursorInputs, onResult, onEve
     player.seek(currentTimeMs);
 
     for (const cursor of cursors) {
-      cursor.snap(currentTimeMs);
+      cursor.seek(currentTimeMs);
     }
   };
   const onProgressDragStart = () => {
@@ -59,7 +59,7 @@ export const Vexml = ({ musicXML, backend, config, cursorInputs, onResult, onEve
     player.addEventListener('progress', (currentTimeMs: number) => {
       const nextProgress = currentTimeMs / durationMs;
       for (const cursor of cursors) {
-        cursor.snap(currentTimeMs);
+        cursor.seek(currentTimeMs);
       }
       setProgress(nextProgress);
     });

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -28,6 +28,7 @@ type CursorState = {
   hasNext: boolean;
   hasPrevious: boolean;
   partRect: spatial.Rect;
+  measureRect: spatial.Rect;
   systemRect: spatial.Rect;
   playableRect: spatial.Rect;
   cursorRect: spatial.Rect;
@@ -46,6 +47,7 @@ export class Cursor {
 
   private topic = new events.Topic<EventMap>();
   private index = 0;
+  private alpha = 0; // interpolation factor, ranging from 0 to 1
 
   private constructor(
     states: CursorState[],
@@ -64,7 +66,7 @@ export class Cursor {
 
     const systemIndexes = query.select('system').map((system) => system.index);
 
-    const partVerticalRects = systemIndexes.map((systemIndex) => {
+    const partRects = systemIndexes.map((systemIndex) => {
       const rects = query
         .where(rendering.filters.forSystem(systemIndex))
         .select(...PART_VERTICAL_SPAN_RENDERINGS)
@@ -73,7 +75,7 @@ export class Cursor {
       return { systemIndex, rect: spatial.Rect.merge(rects) };
     });
 
-    const systemVerticalRects = systemIndexes.map((systemIndex) => {
+    const systemRects = systemIndexes.map((systemIndex) => {
       const rects = query
         .where(rendering.filters.forSystem(systemIndex))
         .select(...SYSTEM_VERTICAL_SPAN_RENDERINGS)
@@ -81,6 +83,11 @@ export class Cursor {
         .map((model) => model.getBoundingBox());
       return { systemIndex, rect: spatial.Rect.merge(rects) };
     });
+
+    const measureRects = query
+      .select('measure')
+      .map(rendering.InteractionModel.create)
+      .map((model) => ({ measureIndex: model.value.index, rect: model.getBoundingBox() }));
 
     const states = new Array<CursorState>(sequence.getLength());
     for (let index = 0; index < sequence.getLength(); index++) {
@@ -95,12 +102,16 @@ export class Cursor {
       util.assertDefined(interactable);
 
       const systemIndex = interactable.address.getSystemIndex();
+      const measureIndex = interactable.address.getMeasureIndex();
 
-      const partRect = partVerticalRects.find((rect) => rect.systemIndex === systemIndex)?.rect;
+      const partRect = partRects.find((rect) => rect.systemIndex === systemIndex)?.rect;
       util.assertDefined(partRect);
 
-      const systemRect = systemVerticalRects.find((rect) => rect.systemIndex === systemIndex)?.rect;
+      const systemRect = systemRects.find((rect) => rect.systemIndex === systemIndex)?.rect;
       util.assertDefined(systemRect);
+
+      const measureRect = measureRects.find((rect) => rect.measureIndex === measureIndex)?.rect;
+      util.assertDefined(measureRect);
 
       const playableRect = rendering.InteractionModel.create(interactable).getBoundingBox();
 
@@ -111,7 +122,17 @@ export class Cursor {
 
       const cursorRect = new spatial.Rect(x, y, w, h);
 
-      states[index] = { index, hasPrevious, hasNext, systemRect, partRect, playableRect, cursorRect, sequenceEntry };
+      states[index] = {
+        index,
+        hasPrevious,
+        hasNext,
+        systemRect,
+        measureRect,
+        partRect,
+        playableRect,
+        cursorRect,
+        sequenceEntry,
+      };
     }
 
     const cheapLocator = new CheapLocator(sequence);
@@ -121,35 +142,96 @@ export class Cursor {
   }
 
   getState(): CursorState {
-    return this.states[this.index];
+    const state = this.states.at(this.index);
+    util.assertDefined(state);
+
+    if (this.alpha === 0) {
+      return { ...state };
+    }
+
+    const currentSystemId = state.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
+    util.assertDefined(currentSystemId);
+
+    const nextState = this.states.at(this.index + 1);
+    const nextSystemId = nextState?.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
+
+    if (nextState && currentSystemId === nextSystemId && nextState.cursorRect.x < state.cursorRect.x) {
+      // The next state is in the same system and is to the left of the current state. This can happen when processing
+      // repeats. Instead of interpolating with the next state, interpolate with the edge of the measure.
+      const leftX = state.cursorRect.x;
+      const rightX = state.measureRect.x + state.measureRect.w;
+      const x = util.lerp(leftX, rightX, this.alpha);
+      const y = state.cursorRect.y;
+      const w = CURSOR_WIDTH_PX;
+      const h = state.cursorRect.h;
+
+      const cursorRect = new spatial.Rect(x, y, w, h);
+
+      return { ...state, cursorRect };
+    }
+
+    if (nextState && currentSystemId === nextSystemId) {
+      // Interpolate with the nextState in the same system.
+      const leftX = state.cursorRect.center().x;
+      const rightX = nextState.cursorRect.center().x;
+      const x = util.lerp(leftX, rightX, this.alpha);
+      const y = state.cursorRect.y;
+      const w = CURSOR_WIDTH_PX;
+      const h = state.cursorRect.h;
+
+      const cursorRect = new spatial.Rect(x, y, w, h);
+
+      return { ...state, cursorRect };
+    }
+
+    // Otherwise, interpolate with the edge of the system, since the next state does not exist or is in a different
+    // system.
+    const leftX = state.cursorRect.center().x;
+    const rightX = state.systemRect.x + state.systemRect.w;
+    const x = util.lerp(leftX, rightX, this.alpha);
+    const y = state.cursorRect.y;
+    const w = CURSOR_WIDTH_PX;
+    const h = state.cursorRect.h;
+
+    const cursorRect = new spatial.Rect(x, y, w, h);
+
+    return { ...state, cursorRect };
   }
 
   next(): void {
-    this.update(this.index + 1);
+    this.update(this.index + 1, 0);
   }
 
   previous(): void {
-    this.update(this.index - 1);
+    this.update(this.index - 1, 0);
   }
 
   goTo(index: number): void {
-    this.update(index);
+    this.update(index, 0);
   }
 
   /** Snaps to the closest sequence entry step. */
   snap(timeMs: number): void {
     timeMs = util.clamp(0, this.sequence.getDuration().ms, timeMs);
     const time = playback.Duration.ms(timeMs);
-    const index = this.cheapLocator.setStartingIndex(this.index).locate(time) ?? this.expensiveLocator.locate(time);
-    if (typeof index !== 'number') {
-      throw new Error(`locator coverage is insufficient to locate time ${timeMs}`);
-    }
-    this.update(index);
+    const index = this.getIndexClosestTo(time);
+    this.update(index, 0);
   }
 
   /** Seeks to the exact position, interpolating as needed. */
   seek(timeMs: number): void {
-    throw new Error('not implemented');
+    timeMs = util.clamp(0, this.sequence.getDuration().ms, timeMs);
+    const time = playback.Duration.ms(timeMs);
+    const index = this.getIndexClosestTo(time);
+
+    const entry = this.sequence.getEntry(index);
+    util.assertNotNull(entry);
+
+    const left = entry.durationRange.getLeft();
+    const right = entry.durationRange.getRight();
+    const alpha = (time.ms - left.ms) / (right.ms - left.ms);
+
+    this.update(index, alpha);
   }
 
   addEventListener<N extends keyof EventMap>(name: N, listener: events.EventListener<EventMap[N]>): number {
@@ -162,11 +244,21 @@ export class Cursor {
     }
   }
 
-  private update(index: number): void {
+  private update(index: number, alpha: number): void {
     index = util.clamp(0, this.sequence.getLength() - 1, index);
-    if (index !== this.index) {
+    alpha = util.clamp(0, 1, alpha);
+    if (index !== this.index || alpha !== this.alpha) {
       this.index = index;
+      this.alpha = alpha;
       this.topic.publish('change', this.getState());
     }
+  }
+
+  private getIndexClosestTo(time: playback.Duration): number {
+    const index = this.cheapLocator.setStartingIndex(this.index).locate(time) ?? this.expensiveLocator.locate(time);
+    if (typeof index !== 'number') {
+      throw new Error(`locator coverage is insufficient to locate time ${time.ms}`);
+    }
+    return index;
   }
 }

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -162,6 +162,8 @@ export class Cursor {
     // "Normally" here means the next state is either in the same measure or the next measure to the right of the
     // current state.
     const isAdvancingNormally =
+      // TODO: Add a "key" interactable instead of assuming the first interactable is the changing one.
+      state.sequenceEntry.interactables[0] !== nextState?.sequenceEntry.interactables[0] &&
       typeof nextMeasureIndex === 'number' &&
       (currentMeasureIndex === nextMeasureIndex || currentMeasureIndex === nextMeasureIndex - 1);
 

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -152,11 +152,15 @@ export class Cursor {
     const currentSystemId = state.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
     util.assertDefined(currentSystemId);
 
+    const currentMeasureIndex = state.sequenceEntry.interactables.at(0)?.address.getMeasureIndex();
+    util.assertDefined(currentMeasureIndex);
+
     const nextState = this.states.at(this.index + 1);
     const nextSystemId = nextState?.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
+    const nextMeasureIndex = nextState?.sequenceEntry.interactables.at(0)?.address.getMeasureIndex();
 
-    if (nextState && currentSystemId === nextSystemId && nextState.cursorRect.x < state.cursorRect.x) {
-      // The next state is in the same system and is to the left of the current state. This can happen when processing
+    if (nextState && currentSystemId === nextSystemId && currentMeasureIndex + 1 !== nextMeasureIndex) {
+      // The next state is in the same system and is not immediately in the next measure. This is common when processing
       // repeats. Instead of interpolating with the next state, interpolate with the edge of the measure.
       const leftX = state.cursorRect.x;
       const rightX = state.measureRect.x + state.measureRect.w;

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -159,7 +159,13 @@ export class Cursor {
     const nextSystemId = nextState?.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
     const nextMeasureIndex = nextState?.sequenceEntry.interactables.at(0)?.address.getMeasureIndex();
 
-    if (nextState && currentSystemId === nextSystemId && currentMeasureIndex + 1 !== nextMeasureIndex) {
+    // "Normally" here means the next state is either in the same measure or the next measure to the right of the
+    // current state.
+    const isAdvancingNormally =
+      typeof nextMeasureIndex === 'number' &&
+      (currentMeasureIndex === nextMeasureIndex || currentMeasureIndex === nextMeasureIndex - 1);
+
+    if (nextState && currentSystemId === nextSystemId && !isAdvancingNormally) {
       // The next state is in the same system and is not immediately in the next measure. This is common when processing
       // repeats. Instead of interpolating with the next state, interpolate with the edge of the measure.
       const leftX = state.cursorRect.x;

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -36,3 +36,9 @@ export const gcd = (a: number, b: number): number => {
 export const lcm = (a: number, b: number): number => {
   return (a * b) / gcd(a, b);
 };
+
+/** Interpolates between a and b. */
+export const lerp = (a: number, b: number, alpha: number): number => {
+  alpha = clamp(0, 1, alpha);
+  return a + (b - a) * alpha;
+};


### PR DESCRIPTION
This PR implements `Cursor.seek`, which is the interpolated alternative to `Cursor.snap`.

https://github.com/user-attachments/assets/e56e163f-a625-48cc-816b-a99b6e735bb0

It also supports repeats!

https://github.com/user-attachments/assets/1c41c1c9-2dc8-4903-af03-7b8242447f9a

Next, I think I'll introduce a max height for the vexml container, and allow the cursor to scroll the container if the cursor is not in view. This will be an option that's controlled in `Cursor.seek` or `Cursor.snap`.