### PR TITLE
Allow rendering to be automatically scrolled based on cursor

### DIFF
--- a/site/src/components/ConfigForm.tsx
+++ b/site/src/components/ConfigForm.tsx
@@ -2,11 +2,6 @@ import * as vexml from '@/index';
 import { CSSProperties, useId, useRef, useState } from 'react';
 import { useTooltip } from '../hooks/useTooltip';
 
-export type ConfigFormProps = {
-  defaultValue?: vexml.Config;
-  onChange(config: vexml.Config): void;
-};
-
 const SLIDER_VALUE_STYLE: CSSProperties = { width: '3em' };
 
 const DESCRIPTOR_TYPE_ORDER = ['string', 'number', 'enum', 'boolean', 'debug'] as const;
@@ -16,6 +11,11 @@ const SCHEMA_CONFIG_ENTRIES = Object.entries(vexml.CONFIG_SCHEMA).sort((a, b) =>
   const bIndex = DESCRIPTOR_TYPE_ORDER.indexOf(b[1].type);
   return aIndex - bIndex;
 });
+
+export type ConfigFormProps = {
+  defaultValue?: vexml.Config;
+  onChange(config: vexml.Config): void;
+};
 
 export const ConfigForm = (props: ConfigFormProps) => {
   const [config, setConfig] = useState(props.defaultValue ?? vexml.DEFAULT_CONFIG);

--- a/site/src/components/SourceDisplay.tsx
+++ b/site/src/components/SourceDisplay.tsx
@@ -263,6 +263,7 @@ export const SourceDisplay = (props: SourceProps) => {
           <div className="d-flex justify-content-center">
             <Vexml
               musicXML={musicXML}
+              height={props.source.height === 0 ? undefined : props.source.height}
               cursorInputs={cursorInputs}
               backend={props.source.backend}
               config={props.source.config}

--- a/site/src/components/SourceForm.tsx
+++ b/site/src/components/SourceForm.tsx
@@ -34,7 +34,7 @@ export const SourceForm = (props: SourceFormProps) => {
   const musicXML = source.type === 'local' ? source.musicXML : props.musicXML;
   const onMusicXMLChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (source.type === 'local') {
-      updateLater({ type: 'local', musicXML: e.target.value, backend: source.backend, config: source.config });
+      updateLater({ ...source, type: 'local', musicXML: e.target.value });
     }
   };
 
@@ -42,14 +42,14 @@ export const SourceForm = (props: SourceFormProps) => {
   const pathKey = EXAMPLE_OPTION_KEY_BY_PATH[path] ?? '';
   const onPathChange = (e: SelectEvent<string>) => {
     if (source.type === 'example') {
-      updateNow({ type: 'example', path: e.value, backend: source.backend, config: source.config });
+      updateNow({ ...source, type: 'example', path: e.value });
     }
   };
 
   const url = source.type === 'remote' ? source.url : '';
   const onUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (source.type === 'remote') {
-      updateLater({ type: 'remote', url: e.target.value, backend: source.backend, config: source.config });
+      updateLater({ ...source, type: 'remote', url: e.target.value });
     }
   };
 
@@ -60,6 +60,7 @@ export const SourceForm = (props: SourceFormProps) => {
     musicXML: '',
     backend: 'svg',
     config: DEFAULT_CONFIG,
+    height: 0,
   });
   const onModalContinue = () => {
     updateNow(modalSource);
@@ -72,7 +73,7 @@ export const SourceForm = (props: SourceFormProps) => {
       throw new Error(`Invalid source type: ${type}`);
     }
 
-    const source = getDefaultSource(type, props.source.backend, props.source.config);
+    const source = getDefaultSource(type, props.source.backend, props.source.config, props.source.height);
 
     const isSourceEmpty =
       (props.source.type === 'local' && props.source.musicXML.length === 0) ||
@@ -88,8 +89,14 @@ export const SourceForm = (props: SourceFormProps) => {
     }
   };
 
+  const heightId = useId();
+  const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const height = parseInt(e.target.value, 10);
+    updateLater({ ...source, height });
+  };
+
   const onConvertToLocalClick = () => {
-    const source = getDefaultSource('local', props.source.backend, props.source.config) as Extract<
+    const source = getDefaultSource('local', props.source.backend, props.source.config, props.source.height) as Extract<
       Source,
       { type: 'local' }
     >;
@@ -104,7 +111,11 @@ export const SourceForm = (props: SourceFormProps) => {
 
     try {
       const vexml = await Vexml.fromFile(files[0]);
-      updateNow({ type: 'local', musicXML: vexml.getDocumentString(), backend: source.backend, config: source.config });
+      updateNow({
+        ...source,
+        type: 'local',
+        musicXML: vexml.getDocumentString(),
+      });
     } catch (e) {
       console.error(`error reading file: ${e}`);
     }
@@ -125,48 +136,72 @@ export const SourceForm = (props: SourceFormProps) => {
 
   return (
     <div>
-      <div>
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name={sourceTypeRadioName}
-            id={localRadioId}
-            value="local"
-            checked={props.source.type === 'local'}
-            onChange={onRadioChange}
-          />
-          <label className="form-check-label" htmlFor={localRadioId}>
-            local
-          </label>
+      <div className="row align-items-center">
+        <div className="col-12 col-md-6 col-lg-8">
+          <div className="form-check form-check-inline">
+            <input
+              className="form-check-input"
+              type="radio"
+              name={sourceTypeRadioName}
+              id={localRadioId}
+              value="local"
+              checked={props.source.type === 'local'}
+              onChange={onRadioChange}
+            />
+            <label className="form-check-label" htmlFor={localRadioId}>
+              local
+            </label>
+          </div>
+          <div className="form-check form-check-inline">
+            <input
+              className="form-check-input"
+              type="radio"
+              name={sourceTypeRadioName}
+              id={exampleRadioId}
+              value="example"
+              checked={props.source.type === 'example'}
+              onChange={onRadioChange}
+            />
+            <label className="form-check-label" htmlFor={exampleRadioId}>
+              example
+            </label>
+          </div>
+          <div className="form-check form-check-inline">
+            <input
+              className="form-check-input"
+              type="radio"
+              name={sourceTypeRadioName}
+              id={remoteRadioId}
+              value="remote"
+              checked={props.source.type === 'remote'}
+              onChange={onRadioChange}
+            />
+            <label className="form-check-label" htmlFor={remoteRadioId}>
+              remote
+            </label>
+          </div>
         </div>
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name={sourceTypeRadioName}
-            id={exampleRadioId}
-            value="example"
-            checked={props.source.type === 'example'}
-            onChange={onRadioChange}
-          />
-          <label className="form-check-label" htmlFor={exampleRadioId}>
-            example
-          </label>
-        </div>
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name={sourceTypeRadioName}
-            id={remoteRadioId}
-            value="remote"
-            checked={props.source.type === 'remote'}
-            onChange={onRadioChange}
-          />
-          <label className="form-check-label" htmlFor={remoteRadioId}>
-            remote
-          </label>
+
+        <div className="col-12 col-md-6 col-lg-4 my-4 my-md-0">
+          <div>
+            <label htmlFor={heightId} className="form-label">
+              Height
+            </label>
+            <div className="row">
+              <div className="col-8">
+                <input
+                  id={heightId}
+                  type="range"
+                  className="form-range"
+                  value={source.height ?? 0}
+                  min={0}
+                  max={2400}
+                  onChange={onHeightChange}
+                />
+              </div>
+              <div className="col-4">{source.height ?? 'N/A'}</div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -266,14 +301,14 @@ export const SourceForm = (props: SourceFormProps) => {
 const isSourceType = (value: any): value is Source['type'] =>
   value === 'local' || value === 'remote' || value === 'example';
 
-const getDefaultSource = (type: Source['type'], backend: RenderingBackend, config: Config): Source => {
+const getDefaultSource = (type: Source['type'], backend: RenderingBackend, config: Config, height: number): Source => {
   switch (type) {
     case 'local':
-      return { type, musicXML: '', backend, config };
+      return { type, musicXML: '', backend, config, height };
     case 'remote':
-      return { type, url: '', backend, config };
+      return { type, url: '', backend, config, height };
     case 'example':
-      return { type, path: DEFAULT_EXAMPLE_PATH, backend, config };
+      return { type, path: DEFAULT_EXAMPLE_PATH, backend, config, height };
     default:
       throw new Error(`Invalid source type: ${type}`);
   }

--- a/site/src/components/SourceForm.tsx
+++ b/site/src/components/SourceForm.tsx
@@ -5,6 +5,7 @@ import DragUpload from './DragUpload';
 import { DEFAULT_EXAMPLE_PATH, EXAMPLES } from '../constants';
 import { Select, SelectEvent, SelectOptionGroup } from './Select';
 import { Config, DEFAULT_CONFIG, Vexml } from '@/index';
+import { useTooltip } from '../hooks/useTooltip';
 
 export type SourceFormProps = {
   source: Source;
@@ -66,6 +67,9 @@ export const SourceForm = (props: SourceFormProps) => {
     updateNow(modalSource);
     modal.hide();
   };
+
+  const heightTooltipRef = useRef<HTMLDivElement>(null);
+  useTooltip(heightTooltipRef, 'right', 'The height scroll container in pixels. Set to 0 for auto height.');
 
   const onRadioChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const type = e.target.value;
@@ -187,6 +191,9 @@ export const SourceForm = (props: SourceFormProps) => {
             <label htmlFor={heightId} className="form-label">
               Height
             </label>
+            <small ref={heightTooltipRef} className="ms-2">
+              <i className="bi bi-question-circle"></i>
+            </small>
             <div className="row">
               <div className="col-8">
                 <input
@@ -199,7 +206,7 @@ export const SourceForm = (props: SourceFormProps) => {
                   onChange={onHeightChange}
                 />
               </div>
-              <div className="col-4">{source.height ?? 'N/A'}</div>
+              <div className="col-4">{source.height || 'auto'}</div>
             </div>
           </div>
         </div>

--- a/site/src/components/SourceWorkspace.tsx
+++ b/site/src/components/SourceWorkspace.tsx
@@ -41,7 +41,7 @@ export const SourceWorkspace = (props: SourceWorkspaceProps) => {
   const onAddClick = (index: number) => () => {
     const keyedSource: Keyed<Source> = {
       key: nextKey(),
-      value: { type: 'local', musicXML: '', backend: 'svg', config: vexml.DEFAULT_CONFIG },
+      value: { type: 'local', musicXML: '', backend: 'svg', config: vexml.DEFAULT_CONFIG, height: 0 },
     };
     const nextKeyedSources = [...keyedSources];
     nextKeyedSources.splice(index, 0, keyedSource);

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -118,7 +118,6 @@ export const Vexml = ({
 
     const handles = new Array<number>();
 
-    handles.push(rendering.addEventListener('scroll', (event) => console.log(event)));
     handles.push(rendering.addEventListener('click', onEvent));
     handles.push(rendering.addEventListener('longpress', onEvent));
     handles.push(rendering.addEventListener('exit', onEvent));

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -118,6 +118,7 @@ export const Vexml = ({
 
     const handles = new Array<number>();
 
+    handles.push(rendering.addEventListener('scroll', (event) => console.log(event)));
     handles.push(rendering.addEventListener('click', onEvent));
     handles.push(rendering.addEventListener('longpress', onEvent));
     handles.push(rendering.addEventListener('exit', onEvent));

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -9,6 +9,7 @@ const STRINGSYNC_RED = '#FC354C';
 
 export type VexmlProps = {
   musicXML: string;
+  height: number | undefined;
   backend: RenderingBackend;
   config: vexml.Config;
   cursorInputs: CursorInput[];
@@ -23,7 +24,16 @@ export type VexmlResult =
   | { type: 'success'; start: Date; end: Date; width: number; element: HTMLCanvasElement | SVGElement }
   | { type: 'error'; error: Error; start: Date; end: Date; width: number };
 
-export const Vexml = ({ musicXML, backend, config, cursorInputs, onResult, onEvent, onPartIdsChange }: VexmlProps) => {
+export const Vexml = ({
+  musicXML,
+  height,
+  backend,
+  config,
+  cursorInputs,
+  onResult,
+  onEvent,
+  onPartIdsChange,
+}: VexmlProps) => {
   const divRef = useRef<HTMLDivElement>(null);
   const div = divRef.current;
 
@@ -255,6 +265,7 @@ export const Vexml = ({ musicXML, backend, config, cursorInputs, onResult, onEve
     try {
       rendering = vexml.Vexml.fromMusicXML(musicXML).render({
         element: div,
+        height,
         width,
         backend,
         config,
@@ -293,7 +304,7 @@ export const Vexml = ({ musicXML, backend, config, cursorInputs, onResult, onEve
     return () => {
       rendering?.destroy();
     };
-  }, [musicXML, cursorInputs, backend, config, width, div, onResult, onPartIdsChange]);
+  }, [musicXML, height, cursorInputs, backend, config, width, div, onResult, onPartIdsChange]);
 
   const elapsedMs = progress * durationMs;
   const remainingMs = Math.max(0, durationMs - elapsedMs);

--- a/site/src/components/Vexml.tsx
+++ b/site/src/components/Vexml.tsx
@@ -52,7 +52,7 @@ export const Vexml = ({
     player.seek(currentTimeMs);
 
     for (const cursor of cursors) {
-      cursor.seek(currentTimeMs);
+      cursor.seek(currentTimeMs, { scroll: !cursor.isFullyVisible() });
     }
   };
   const onProgressDragStart = () => {
@@ -69,7 +69,7 @@ export const Vexml = ({
     player.addEventListener('progress', (currentTimeMs: number) => {
       const nextProgress = currentTimeMs / durationMs;
       for (const cursor of cursors) {
-        cursor.seek(currentTimeMs);
+        cursor.seek(currentTimeMs, { scroll: !cursor.isFullyVisible() });
       }
       setProgress(nextProgress);
     });

--- a/site/src/hooks/useSources.ts
+++ b/site/src/hooks/useSources.ts
@@ -4,7 +4,7 @@ import { Source } from '../types';
 import { useJsonLocalStorage } from './useJsonLocalStorage';
 
 const DEFAULT_SOURCES: Source[] = [
-  { type: 'example', path: DEFAULT_EXAMPLE_PATH, backend: 'svg', config: vexml.DEFAULT_CONFIG },
+  { type: 'example', path: DEFAULT_EXAMPLE_PATH, backend: 'svg', config: vexml.DEFAULT_CONFIG, height: 0 },
 ];
 
 export const useSources = () => {
@@ -24,6 +24,9 @@ const isSources = (data: unknown): data is Source[] =>
       return false;
     }
     if (item.backend !== 'svg' && item.backend !== 'canvas') {
+      return false;
+    }
+    if (typeof item.height !== 'undefined' && typeof item.height !== 'number') {
       return false;
     }
     if (!isConfig(item.config)) {

--- a/site/src/lib/Player.ts
+++ b/site/src/lib/Player.ts
@@ -42,6 +42,9 @@ export class Player {
 
   play() {
     this.isSuspended = false;
+    if (this.currentTimeMs >= this.durationMs) {
+      this.currentTimeMs = 0;
+    }
     if (this.state === 'playing') {
       return;
     }

--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -7,18 +7,21 @@ export type Source =
       musicXML: string;
       backend: RenderingBackend;
       config: vexml.Config;
+      height: number;
     }
   | {
       type: 'remote';
       url: string;
       backend: RenderingBackend;
       config: vexml.Config;
+      height: number;
     }
   | {
       type: 'example';
       path: string;
       backend: RenderingBackend;
       config: vexml.Config;
+      height: number;
     };
 
 /** A wrapper for keying values. */

--- a/src/components/overlay.ts
+++ b/src/components/overlay.ts
@@ -6,9 +6,9 @@ export class Overlay {
     this.element = element;
   }
 
-  static render(parent: HTMLElement, ...classNames: string[]) {
+  static render(parent: HTMLElement) {
     const element = document.createElement('div');
-    element.classList.add('vexml-overlay', ...classNames);
+    element.classList.add('vexml-overlay');
     element.style.position = 'absolute';
     element.style.top = '0';
     element.style.left = '0';

--- a/src/components/root.ts
+++ b/src/components/root.ts
@@ -14,19 +14,24 @@ export class Root {
     this.overlay = overlay;
   }
 
-  static svg(parent: HTMLElement) {
-    return Root.render('svg', parent);
+  static svg(parent: HTMLElement, height: number | undefined) {
+    return Root.render('svg', parent, height);
   }
 
-  static canvas(parent: HTMLElement) {
-    return Root.render('canvas', parent);
+  static canvas(parent: HTMLElement, height: number | undefined) {
+    return Root.render('canvas', parent, height);
   }
 
-  private static render(type: 'svg' | 'canvas', parent: HTMLElement) {
+  private static render(type: 'svg' | 'canvas', parent: HTMLElement, height: number | undefined): Root {
     const element = document.createElement('div');
 
     element.classList.add('vexml-root');
     element.style.position = 'relative';
+
+    if (typeof height === 'number') {
+      element.style.height = `${height}px`;
+      element.style.overflow = 'auto';
+    }
 
     const overlay = Overlay.render(element);
 

--- a/src/components/root.ts
+++ b/src/components/root.ts
@@ -25,10 +25,12 @@ export class Root {
   private static render(type: 'svg' | 'canvas', parent: HTMLElement, height: number | undefined): Root {
     const vexmlRoot = document.createElement('div');
     vexmlRoot.classList.add('vexml-root');
+    vexmlRoot.classList.add('vexml-scroll-container');
 
     if (typeof height === 'number') {
       vexmlRoot.style.height = `${height}px`;
-      vexmlRoot.style.overflow = 'auto';
+      vexmlRoot.style.overflowY = 'auto';
+      vexmlRoot.style.overflowX = 'hidden';
     }
 
     const vexmlContainer = document.createElement('div');
@@ -60,7 +62,7 @@ export class Root {
     return this.overlay;
   }
 
-  getElement(): HTMLDivElement {
+  getScrollContainer(): HTMLDivElement {
     return this.element;
   }
 

--- a/src/components/root.ts
+++ b/src/components/root.ts
@@ -23,36 +23,36 @@ export class Root {
   }
 
   private static render(type: 'svg' | 'canvas', parent: HTMLElement, height: number | undefined): Root {
-    const element = document.createElement('div');
-
-    element.classList.add('vexml-root');
-    element.style.position = 'relative';
+    const vexmlRoot = document.createElement('div');
+    vexmlRoot.classList.add('vexml-root');
 
     if (typeof height === 'number') {
-      element.style.height = `${height}px`;
-      element.style.overflow = 'auto';
+      vexmlRoot.style.height = `${height}px`;
+      vexmlRoot.style.overflow = 'auto';
     }
 
-    const overlay = Overlay.render(element);
+    const vexmlContainer = document.createElement('div');
+    vexmlContainer.classList.add('vexml-container');
+    vexmlContainer.style.position = 'relative';
+    vexmlRoot.append(vexmlContainer);
 
-    switch (type) {
-      case 'svg':
-        const div = document.createElement('div');
-        div.classList.add('vexml-container');
-        div.classList.add('vexml-container-svg');
-        element.append(div);
-        break;
-      case 'canvas':
-        const canvas = document.createElement('canvas');
-        canvas.classList.add('vexml-container');
-        canvas.classList.add('vexml-container-canvas');
-        element.append(canvas);
-        break;
+    const overlay = Overlay.render(vexmlContainer);
+
+    if (type === 'svg') {
+      const vexflowContainer = document.createElement('div');
+      vexflowContainer.classList.add('vexflow-container');
+      vexflowContainer.classList.add('vexflow-container-svg');
+      vexmlContainer.append(vexflowContainer);
+    } else {
+      const vexflowContainer = document.createElement('canvas');
+      vexflowContainer.classList.add('vexflow-container');
+      vexflowContainer.classList.add('vexflow-container-canvas');
+      vexmlContainer.append(vexflowContainer);
     }
 
-    parent.append(element);
+    parent.append(vexmlRoot);
 
-    return new Root(element, overlay);
+    return new Root(vexmlRoot, overlay);
   }
 
   /** Returns the Overlay component. */
@@ -62,13 +62,17 @@ export class Root {
 
   /** Returns the element that is intended to be inputted to vexflow. */
   getVexflowContainerElement(): HTMLDivElement | HTMLCanvasElement {
-    return this.element.querySelector('.vexml-container') as HTMLDivElement | HTMLCanvasElement;
+    return this.element.querySelector('.vexflow-container') as HTMLDivElement | HTMLCanvasElement;
   }
 
   /** Returns the element that vexflow rendered onto. */
   getVexflowElement(): SVGElement | HTMLCanvasElement {
     const container = this.getVexflowContainerElement();
-    return container instanceof HTMLDivElement ? (container.firstElementChild as SVGElement) : container;
+    if (container instanceof HTMLDivElement) {
+      return container.firstElementChild as SVGElement;
+    } else {
+      return container as HTMLCanvasElement;
+    }
   }
 
   /** Removes the element from the DOM. */

--- a/src/components/root.ts
+++ b/src/components/root.ts
@@ -60,6 +60,10 @@ export class Root {
     return this.overlay;
   }
 
+  getElement(): HTMLDivElement {
+    return this.element;
+  }
+
   /** Returns the element that is intended to be inputted to vexflow. */
   getVexflowContainerElement(): HTMLDivElement | HTMLCanvasElement {
     return this.element.querySelector('.vexflow-container') as HTMLDivElement | HTMLCanvasElement;

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -40,6 +40,7 @@ type EventMap = {
 };
 
 export class Cursor {
+  private scrollContainer: HTMLElement;
   private states: CursorState[];
   private sequence: playback.Sequence;
   private cheapLocator: CheapLocator;
@@ -49,19 +50,27 @@ export class Cursor {
   private index = 0;
   private alpha = 0; // interpolation factor, ranging from 0 to 1
 
-  private constructor(
-    states: CursorState[],
-    sequence: playback.Sequence,
-    cheapLocator: CheapLocator,
-    expensiveLocator: ExpensiveLocator
-  ) {
-    this.states = states;
-    this.sequence = sequence;
-    this.cheapLocator = cheapLocator;
-    this.expensiveLocator = expensiveLocator;
+  private constructor(opts: {
+    scrollContainer: HTMLElement;
+    states: CursorState[];
+    sequence: playback.Sequence;
+    cheapLocator: CheapLocator;
+    expensiveLocator: ExpensiveLocator;
+  }) {
+    this.scrollContainer = opts.scrollContainer;
+    this.states = opts.states;
+    this.sequence = opts.sequence;
+    this.cheapLocator = opts.cheapLocator;
+    this.expensiveLocator = opts.expensiveLocator;
   }
 
-  static create(score: rendering.ScoreRendering, partId: string, sequence: playback.Sequence): Cursor {
+  static create(opts: {
+    scrollContainer: HTMLElement;
+    score: rendering.ScoreRendering;
+    partId: string;
+    sequence: playback.Sequence;
+  }): Cursor {
+    const { score, partId, sequence } = opts;
     const query = rendering.Query.of(score).where(rendering.filters.forPart(partId));
 
     const systemIndexes = query.select('system').map((system) => system.index);
@@ -138,7 +147,13 @@ export class Cursor {
     const cheapLocator = new CheapLocator(sequence);
     const expensiveLocator = new ExpensiveLocator(sequence);
 
-    return new Cursor(states, sequence, cheapLocator, expensiveLocator);
+    return new Cursor({
+      scrollContainer: opts.scrollContainer,
+      states,
+      sequence,
+      cheapLocator,
+      expensiveLocator,
+    });
   }
 
   getState(): CursorState {

--- a/src/cursors/cursor.ts
+++ b/src/cursors/cursor.ts
@@ -97,7 +97,7 @@ export class Cursor {
       const hasPrevious = index > 0;
       const hasNext = index < sequence.getLength() - 1;
 
-      const interactable = sequenceEntry.interactables.at(0);
+      const interactable = sequenceEntry.mostRecentInteractable;
 
       util.assertDefined(interactable);
 
@@ -149,21 +149,20 @@ export class Cursor {
       return { ...state };
     }
 
-    const currentSystemId = state.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
+    const currentSystemId = state.sequenceEntry.mostRecentInteractable?.address.getSystemIndex();
     util.assertDefined(currentSystemId);
 
-    const currentMeasureIndex = state.sequenceEntry.interactables.at(0)?.address.getMeasureIndex();
+    const currentMeasureIndex = state.sequenceEntry.mostRecentInteractable?.address.getMeasureIndex();
     util.assertDefined(currentMeasureIndex);
 
     const nextState = this.states.at(this.index + 1);
-    const nextSystemId = nextState?.sequenceEntry.interactables.at(0)?.address.getSystemIndex();
-    const nextMeasureIndex = nextState?.sequenceEntry.interactables.at(0)?.address.getMeasureIndex();
+    const nextSystemId = nextState?.sequenceEntry.mostRecentInteractable?.address.getSystemIndex();
+    const nextMeasureIndex = nextState?.sequenceEntry.mostRecentInteractable?.address.getMeasureIndex();
 
     // "Normally" here means the next state is either in the same measure or the next measure to the right of the
     // current state.
     const isAdvancingNormally =
-      // TODO: Add a "key" interactable instead of assuming the first interactable is the changing one.
-      state.sequenceEntry.interactables[0] !== nextState?.sequenceEntry.interactables[0] &&
+      state.sequenceEntry.mostRecentInteractable !== nextState?.sequenceEntry.mostRecentInteractable &&
       typeof nextMeasureIndex === 'number' &&
       (currentMeasureIndex === nextMeasureIndex || currentMeasureIndex === nextMeasureIndex - 1);
 

--- a/src/cursors/scroller.ts
+++ b/src/cursors/scroller.ts
@@ -1,0 +1,33 @@
+import * as spatial from '@/spatial';
+
+export class Scroller {
+  constructor(private scrollContainer: HTMLElement) {}
+
+  isFullyVisible(rect: spatial.Rect): boolean {
+    const visibleRect = this.getVisibleRect();
+    return (
+      rect.x >= visibleRect.x &&
+      rect.y >= visibleRect.y &&
+      rect.x + rect.w <= visibleRect.x + visibleRect.w &&
+      rect.y + rect.h <= visibleRect.y + visibleRect.h
+    );
+  }
+
+  scrollTo(point: spatial.Point) {
+    if (this.scrollContainer.scrollLeft !== point.x || this.scrollContainer.scrollTop !== point.y) {
+      this.scrollContainer.scrollTo({
+        top: point.y,
+        left: point.x,
+        behavior: 'smooth',
+      });
+    }
+  }
+
+  private getVisibleRect(): spatial.Rect {
+    const scrollLeft = this.scrollContainer.scrollLeft;
+    const scrollTop = this.scrollContainer.scrollTop;
+    const scrollWidth = this.scrollContainer.clientWidth;
+    const scrollHeight = this.scrollContainer.clientHeight;
+    return new spatial.Rect(scrollLeft, scrollTop, scrollWidth, scrollHeight);
+  }
+}

--- a/src/events/nativebridge.ts
+++ b/src/events/nativebridge.ts
@@ -18,7 +18,7 @@ export type EventMapping<V extends string[]> = {
  * - Native events are only added to the host element when they are needed.
  */
 export class NativeBridge<V extends string> {
-  private scrollElement: HTMLElement;
+  private scrollContainer: HTMLElement;
   private overlayElement: HTMLElement;
   private mappings: EventMapping<V[]>[];
   private nativeEventTopic: Topic<HTMLElementEventMap>;
@@ -28,13 +28,13 @@ export class NativeBridge<V extends string> {
   private handles: { [K in V]?: number[] } = {};
 
   constructor(opts: {
-    scrollElement: HTMLElement;
+    scrollContainer: HTMLElement;
     overlayElement: HTMLElement;
     mappings: EventMapping<V[]>[];
     nativeEventTopic: Topic<HTMLElementEventMap>;
     nativeEventOpts: { [K in keyof HTMLElementEventMap]?: AddEventListenerOptions };
   }) {
-    this.scrollElement = opts.scrollElement;
+    this.scrollContainer = opts.scrollContainer;
     this.overlayElement = opts.overlayElement;
     this.mappings = opts.mappings;
     this.nativeEventTopic = opts.nativeEventTopic;
@@ -69,7 +69,7 @@ export class NativeBridge<V extends string> {
       // Enforce only a single listener per native event. vexml is intended to consume the event through the
       // nativeEventTopic. That way, we only run the native callbacks that we need to run.
       if (!this.nativeEventTopic.hasSubscribers(nativeEventName)) {
-        const srcElement = mapping.src === 'scroll' ? this.scrollElement : this.overlayElement;
+        const srcElement = mapping.src === 'scroll' ? this.scrollContainer : this.overlayElement;
         srcElement.addEventListener(nativeEventName, this.publishNativeEvent, this.nativeEventOpts[nativeEventName]);
       }
       const handle = this.nativeEventTopic.subscribe(nativeEventName, nativeEventListener);
@@ -100,7 +100,7 @@ export class NativeBridge<V extends string> {
       const nativeEventName = native[0] as keyof HTMLElementEventMap;
 
       if (!this.nativeEventTopic.hasSubscribers(nativeEventName)) {
-        const srcElement = mapping.src === 'scroll' ? this.scrollElement : this.overlayElement;
+        const srcElement = mapping.src === 'scroll' ? this.scrollContainer : this.overlayElement;
         srcElement.removeEventListener(nativeEventName, this.publishNativeEvent, this.nativeEventOpts[nativeEventName]);
       }
     }

--- a/src/playback/sequence.ts
+++ b/src/playback/sequence.ts
@@ -31,6 +31,7 @@ type SequenceEvent = {
 };
 
 export type SequenceEntry = {
+  mostRecentInteractable: rendering.InteractableRendering;
   interactables: rendering.InteractableRendering[];
   durationRange: DurationRange;
 };
@@ -93,9 +94,11 @@ export class Sequence {
       const interactables = new Array<rendering.InteractableRendering>();
       const entries = new Array<SequenceEntry>();
       let time = Duration.zero();
+      let mostRecentInteractable: rendering.InteractableRendering | null = null;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       util.forEachTriple(events, ([previousEvent, currentEvent, nextEvent]) => {
         if (currentEvent.type === 'start') {
+          mostRecentInteractable = currentEvent.interactable;
           interactables.unshift(currentEvent.interactable);
         }
 
@@ -108,7 +111,8 @@ export class Sequence {
           const stop = nextEvent.time;
           const durationRange = new DurationRange(start, stop);
           time = stop;
-          entries.push({ interactables: [...interactables], durationRange });
+          util.assertNotNull(mostRecentInteractable);
+          entries.push({ mostRecentInteractable, interactables: [...interactables], durationRange });
         }
       });
 

--- a/src/rendering/events.ts
+++ b/src/rendering/events.ts
@@ -61,25 +61,25 @@ type LocateResult = {
 };
 
 export class EventMappingFactory {
-  private scrollElement: Element;
+  private scrollContainer: Element;
   private overlayElement: Element;
   private locator: spatial.PointLocator<InteractionModelType>;
   private topic: events.Topic<EventMap>;
 
   private constructor(opts: {
-    scrollElement: Element;
+    scrollContainer: Element;
     overlayElement: Element;
     locator: spatial.PointLocator<InteractionModelType>;
     topic: events.Topic<EventMap>;
   }) {
-    this.scrollElement = opts.scrollElement;
+    this.scrollContainer = opts.scrollContainer;
     this.overlayElement = opts.overlayElement;
     this.locator = opts.locator;
     this.topic = opts.topic;
   }
 
   static create(opts: {
-    scrollElement: Element;
+    scrollContainer: Element;
     overlayElement: Element;
     inputType: InputType;
     locator: spatial.PointLocator<InteractionModelType>;
@@ -132,8 +132,8 @@ export class EventMappingFactory {
         scroll: () => {
           this.topic.publish('scroll', {
             type: 'scroll',
-            scrollX: this.scrollElement.scrollLeft,
-            scrollY: this.scrollElement.scrollTop,
+            scrollX: this.scrollContainer.scrollLeft,
+            scrollY: this.scrollContainer.scrollTop,
           });
         },
       },

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -46,7 +46,12 @@ export class Rendering {
     const partId = opts?.partId ?? this.partIds[0];
     const sequence = this.sequences.find((sequence) => sequence.getPartId() === partId);
     util.assertDefined(sequence);
-    return cursors.Cursor.create(this.score, partId, sequence);
+    return cursors.Cursor.create({
+      scrollContainer: this.root.getScrollContainer(),
+      partId,
+      sequence,
+      score: this.score,
+    });
   }
 
   /** Returns the element used as an overlay. */

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -11,6 +11,7 @@ export type RenderOptions = {
   config?: Partial<Config>;
   backend?: 'svg' | 'canvas';
   width: number;
+  height?: number;
 };
 
 /** Vexml contains the core operation of this library: rendering MusicXML in a web browser. */
@@ -83,18 +84,19 @@ export class Vexml {
     const config = { ...DEFAULT_CONFIG, ...opts.config };
     const element = opts.element;
     const width = opts.width;
+    const height = opts.height;
     const backend = opts.backend;
 
     let root: components.Root;
     switch (backend) {
       case 'svg':
-        root = components.Root.svg(element);
+        root = components.Root.svg(element, height);
         break;
       case 'canvas':
-        root = components.Root.canvas(element);
+        root = components.Root.canvas(element, height);
         break;
       default:
-        root = components.Root.svg(element);
+        root = components.Root.svg(element, height);
     }
 
     // Render score.

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -115,7 +115,7 @@ export class Vexml {
     const overlay = root.getOverlay();
     const vexmlEventTopic = new events.Topic<rendering.EventMap>();
     const nativeEventTopic = new events.Topic<HTMLElementEventMap>();
-    const scrollElement = root.getElement();
+    const scrollElement = root.getScrollContainer();
     const overlayElement = overlay.getElement();
     const mappings = rendering.EventMappingFactory.create({
       scrollElement,

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -115,17 +115,17 @@ export class Vexml {
     const overlay = root.getOverlay();
     const vexmlEventTopic = new events.Topic<rendering.EventMap>();
     const nativeEventTopic = new events.Topic<HTMLElementEventMap>();
-    const scrollElement = root.getScrollContainer();
+    const scrollContainer = root.getScrollContainer();
     const overlayElement = overlay.getElement();
     const mappings = rendering.EventMappingFactory.create({
-      scrollElement,
+      scrollContainer,
       overlayElement,
       locator,
       inputType: config.INPUT_TYPE,
       topic: vexmlEventTopic,
     });
     const bridge = new events.NativeBridge<keyof rendering.EventMap>({
-      scrollElement,
+      scrollContainer,
       overlayElement,
       mappings,
       nativeEventTopic,

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -115,14 +115,17 @@ export class Vexml {
     const overlay = root.getOverlay();
     const vexmlEventTopic = new events.Topic<rendering.EventMap>();
     const nativeEventTopic = new events.Topic<HTMLElementEventMap>();
+    const scrollElement = root.getElement();
     const overlayElement = overlay.getElement();
     const mappings = rendering.EventMappingFactory.create({
+      scrollElement,
       overlayElement,
       locator,
       inputType: config.INPUT_TYPE,
       topic: vexmlEventTopic,
     });
     const bridge = new events.NativeBridge<keyof rendering.EventMap>({
+      scrollElement,
       overlayElement,
       mappings,
       nativeEventTopic,


### PR DESCRIPTION
This PR adds `Cursor.isFullyVisible` and a `scroll: boolean` option to `Cursor.snap` and `Cursor.seek`. It is the caller's responsibility to decide if to scroll or not. By being less prescriptive about how a MusicXML document should be scrolled, there are different scroll schemes that can be done. For example:

- scroll whenever the cursor is not fully visible (this is what's on the site)
- scroll whenever the cursor changes systems
- "paged" scrolling: assign systems to a page, then only scroll when the page changes
- etc.

The caller can also listen to the rendering's `scroll` event.

> [!NOTE]  
> `scrollTo` with `behavior: 'smooth'` is asynchronous, but the API is synchronous. It's possible to get in a bad scroll state if changed too quickly.

https://github.com/user-attachments/assets/26dd630a-e8dc-4df5-a3e8-5a7631b144a4