### PR TITLE
Add MEASURE_NUMBERING_SCHEME config

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -59,12 +59,8 @@ export const CONFIG_SCHEMA = {
     defaultValue: 200,
     help: 'MULTI_MEASURE_REST_WIDTH is the width of multi-measure rests.',
   }),
-  ENABLE_MEASURE_NUMBERS: t.boolean({
-    defaultValue: true,
-    help: 'ENABLE_MEASURE_NUMBERS enables measure numbers to be displayed.',
-  }),
   MEASURE_NUMBERING_SCHEME: t.enum({
-    choices: ['all', 'sparse', 'system', 'none'],
+    choices: ['all', 'every2', 'every3', 'system', 'none'] as const,
     defaultValue: 'all',
     help: 'MEASURE_NUMBERING_SCHEME is the scheme for numbering measures.',
   }),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -63,6 +63,11 @@ export const CONFIG_SCHEMA = {
     defaultValue: true,
     help: 'ENABLE_MEASURE_NUMBERS enables measure numbers to be displayed.',
   }),
+  MEASURE_NUMBERING_SCHEME: t.enum({
+    choices: ['all', 'sparse', 'system', 'none'],
+    defaultValue: 'all',
+    help: 'MEASURE_NUMBERING_SCHEME is the scheme for numbering measures.',
+  }),
   INPUT_TYPE: t.enum({
     choices: ['auto', 'none', 'mouse', 'touch', 'hybrid'] as const,
     defaultValue: 'auto',

--- a/src/rendering/measure.ts
+++ b/src/rendering/measure.ts
@@ -297,7 +297,7 @@ export class Measure {
 
         const vfStave = util.first(vfStaves);
         const measureNumber = this.getMeasureNumber();
-        if (isFirst && this.config.ENABLE_MEASURE_NUMBERS && vfStave && typeof measureNumber === 'number') {
+        if (isFirst && this.shouldShowMeasureNumber(opts.address) && vfStave && typeof measureNumber === 'number') {
           vfStave.setMeasure(measureNumber);
         }
 
@@ -515,6 +515,23 @@ export class Measure {
 
   private getBpm(): number | null {
     return this.bpm;
+  }
+
+  private shouldShowMeasureNumber(address: Address<'measure'>): boolean {
+    const systemMeasureIndex = address.getSystemMeasureIndex()!;
+
+    switch (this.config.MEASURE_NUMBERING_SCHEME) {
+      case 'all':
+        return true;
+      case 'every2':
+        return systemMeasureIndex % 2 === 0;
+      case 'every3':
+        return systemMeasureIndex % 3 === 0;
+      case 'system':
+        return systemMeasureIndex === 0;
+      case 'none':
+        return false;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes #252. The `ENABLE_MEASURE_NUMBERS` config has been replaced by `MEASURE_NUMBERING_SCHEME`.

## all

<img width="679" alt="image" src="https://github.com/user-attachments/assets/60c6b7a0-33e3-4452-a13c-e2ab9acea7ce" />

## every2

<img width="666" alt="image" src="https://github.com/user-attachments/assets/d9c4912a-6a92-4971-87c3-a8abac35dee0" />

## every3

<img width="908" alt="image" src="https://github.com/user-attachments/assets/201c2a90-986b-46b5-a043-e7b6135eeac0" />

## system

<img width="895" alt="image" src="https://github.com/user-attachments/assets/bfc270d0-79ee-4831-a1e9-f1331066f561" />

## none

<img width="912" alt="image" src="https://github.com/user-attachments/assets/97992763-3cf3-4a41-af40-65c78637124e" />