### PR TITLE
Rename MessageMeasure to Gap and refactor

### DIFF
--- a/src/drawables/circle.ts
+++ b/src/drawables/circle.ts
@@ -3,16 +3,18 @@ import * as vexflow from 'vexflow';
 
 export class Circle {
   private circle: spatial.Circle;
-  private strokeStyle?: string;
+  private strokeStyle: string | null;
 
-  constructor(opts: { circle: spatial.Circle; strokeStyle?: string }) {
+  constructor(opts: { circle: spatial.Circle; strokeStyle: string | null }) {
     this.circle = opts.circle;
     this.strokeStyle = opts.strokeStyle;
   }
 
   draw(vfContext: vexflow.RenderContext): void {
     vfContext.save();
-    vfContext.setStrokeStyle(this.strokeStyle ?? 'black');
+    if (this.strokeStyle) {
+      vfContext.setStrokeStyle(this.strokeStyle);
+    }
     vfContext.beginPath();
     vfContext.arc(this.circle.x, this.circle.y, this.circle.r, 0, Math.PI * 2, false);
     vfContext.stroke();

--- a/src/drawables/rect.ts
+++ b/src/drawables/rect.ts
@@ -1,13 +1,14 @@
-import * as spatial from '@/spatial';
 import * as vexflow from 'vexflow';
 
-export class Rect {
-  private rect: spatial.Rect;
-  private strokeStyle?: string;
-  private fillStyle?: string;
+type Box = { x: number; y: number; w: number; h: number };
 
-  constructor(opts: { rect: spatial.Rect; strokeStyle?: string; fillStyle?: string }) {
-    this.rect = opts.rect;
+export class Rect {
+  private bounds: Box;
+  private strokeStyle: string | null;
+  private fillStyle: string | null;
+
+  constructor(opts: { bounds: Box; strokeStyle: string | null; fillStyle: string | null }) {
+    this.bounds = opts.bounds;
     this.strokeStyle = opts.strokeStyle;
     this.fillStyle = opts.fillStyle;
   }
@@ -17,13 +18,13 @@ export class Rect {
 
     if (this.strokeStyle) {
       vfContext.setStrokeStyle(this.strokeStyle);
-      vfContext.rect(this.rect.x, this.rect.y, this.rect.w, this.rect.h);
+      vfContext.rect(this.bounds.x, this.bounds.y, this.bounds.w, this.bounds.h);
       vfContext.stroke();
     }
 
     if (this.fillStyle) {
       vfContext.setFillStyle(this.fillStyle);
-      vfContext.fillRect(this.rect.x, this.rect.y, this.rect.w, this.rect.h);
+      vfContext.fillRect(this.bounds.x, this.bounds.y, this.bounds.w, this.bounds.h);
     }
 
     vfContext.restore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './vexml';
 export * from './rendering/events';
-export { type Rendering, type MessageMeasure } from './rendering';
+export { type Rendering, type Gap } from './rendering';
 export { SimpleCursor } from './components';
 export { CONFIG_SCHEMA, DEFAULT_CONFIG } from './config';
 export type { Config, SchemaDescriptor, SchemaType, SchemaConfig } from './config';

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -15,4 +15,4 @@ export * from './interactions';
 export * from './query';
 export * from './ghostnote';
 export * from './locator';
-export { type MessageMeasure } from './types';
+export { type Gap } from './types';

--- a/src/rendering/locator.ts
+++ b/src/rendering/locator.ts
@@ -65,7 +65,7 @@ export class Locator {
     for (const target of targets) {
       for (const shape of target.getShapes()) {
         if (shape instanceof spatial.Rect) {
-          const rect = new drawables.Rect({ rect: shape, strokeStyle: TRANSPARENT_RED });
+          const rect = new drawables.Rect({ bounds: shape, strokeStyle: TRANSPARENT_RED, fillStyle: null });
           rect.draw(ctx);
         } else if (shape instanceof spatial.Circle) {
           const circle = new drawables.Circle({ circle: shape, strokeStyle: TRANSPARENT_RED });
@@ -75,7 +75,7 @@ export class Locator {
     }
 
     for (const boundary of this.tree.getBoundaries()) {
-      const rect = new drawables.Rect({ rect: boundary, strokeStyle: TRANSPARENT_BLUE });
+      const rect = new drawables.Rect({ bounds: boundary, strokeStyle: TRANSPARENT_BLUE, fillStyle: null });
       rect.draw(ctx);
     }
   }

--- a/src/rendering/score.ts
+++ b/src/rendering/score.ts
@@ -13,7 +13,7 @@ import { Seed } from './seed';
 import { Spanners } from './spanners';
 import { Address } from './address';
 import { ChorusRendering } from './chorus';
-import { MessageMeasure } from './types';
+import { Gap } from './types';
 
 const Y_SHIFT_PADDING = 10;
 
@@ -39,7 +39,7 @@ export class Score {
   private musicXML: {
     scorePartwise: musicxml.ScorePartwise | null;
   };
-  private messageMeasures: MessageMeasure[];
+  private gaps: Gap[];
 
   constructor(opts: {
     config: Config;
@@ -47,12 +47,12 @@ export class Score {
     musicXML: {
       scorePartwise: musicxml.ScorePartwise | null;
     };
-    messageMeasures: MessageMeasure[];
+    gaps: Gap[];
   }) {
     this.config = opts.config;
     this.log = opts.log;
     this.musicXML = opts.musicXML;
-    this.messageMeasures = opts.messageMeasures;
+    this.gaps = opts.gaps;
   }
 
   /** Renders the Score. */
@@ -283,7 +283,7 @@ export class Score {
         partDetails: this.musicXML.scorePartwise?.getPartDetails() ?? [],
         staveLayouts: this.musicXML.scorePartwise?.getDefaults()?.getStaveLayouts() ?? [],
       },
-      messageMeasures: this.messageMeasures,
+      gaps: this.gaps,
     });
   }
 

--- a/src/rendering/seed.ts
+++ b/src/rendering/seed.ts
@@ -3,7 +3,7 @@ import { Config } from '@/config';
 import * as musicxml from '@/musicxml';
 import * as util from '@/util';
 import * as debug from '@/debug';
-import { MessageMeasure, PartScoped, StaveScoped } from './types';
+import { Gap, PartScoped, StaveScoped } from './types';
 import { Measure } from './measure';
 import { Address } from './address';
 import { MeasureEntry, StaveSignature } from './stavesignature';
@@ -21,7 +21,7 @@ export class Seed {
     partDetails: musicxml.PartDetail[];
     staveLayouts: musicxml.StaveLayout[];
   };
-  private messageMeasures: MessageMeasure[];
+  private gaps: Gap[];
 
   constructor(opts: {
     config: Config;
@@ -31,12 +31,12 @@ export class Seed {
       partDetails: musicxml.PartDetail[];
       staveLayouts: musicxml.StaveLayout[];
     };
-    messageMeasures: MessageMeasure[];
+    gaps: Gap[];
   }) {
     this.config = opts.config;
     this.log = opts.log;
     this.musicXML = opts.musicXML;
-    this.messageMeasures = opts.messageMeasures;
+    this.gaps = opts.gaps;
   }
 
   /** Splits the measures into parts and systems that fit the given width. */
@@ -99,17 +99,14 @@ export class Seed {
     for (let measureIndex = 0; measureIndex < measureCount; measureIndex++) {
       const leadingStaveSignatures = this.getLeadingStaveSignatures(measureIndex);
 
-      // Keep inserting message measures such that the messageMeasure.absoluteMeasureIndex is honored. Having a
-      // MessageMeasure[] with duplicate absoluteMeasureIndex properties is an error and should be validated and/or
-      // sanitzied upstream.
-      let messageMeasure = this.messageMeasures.find(
-        (messageMeasure) => messageMeasure.absoluteMeasureIndex === measures.length
-      );
-      while (messageMeasure) {
-        const measure = Measure.fromMessageMeasure({
+      // Keep inserting message measures such that the gap.absoluteMeasureIndex is honored. Having a Gap[] with
+      // duplicate absoluteMeasureIndex properties is an error and should be validated and/or sanitzied upstream.
+      let gap = this.gaps.find((gap) => gap.absoluteMeasureIndex === measures.length);
+      while (gap) {
+        const measure = Measure.fromGap({
           config: this.config,
           log: this.log,
-          messageMeasure,
+          gap: gap,
           partIds,
           partNames,
           leadingStaveSignatures,
@@ -117,9 +114,7 @@ export class Seed {
         });
         measures.push(measure);
 
-        messageMeasure = this.messageMeasures.find(
-          (messageMeasure) => messageMeasure.absoluteMeasureIndex === measures.length
-        );
+        gap = this.gaps.find((gap) => gap.absoluteMeasureIndex === measures.length);
       }
 
       if (multiRestMeasureCount > 0) {

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -44,13 +44,10 @@ export type Jump =
   | { type: 'repeatend'; times: number }
   | { type: 'repeatending'; times: number };
 
-/** A directive to insert a non-musical measure with a message. */
-export type MessageMeasure = {
+/** Gap is a non-musical section with an optional message. */
+export type Gap = {
   /** The **absolute** measure index accounting for any previous measures that have been removed or inserted. */
   absoluteMeasureIndex: number;
-
-  /** The message to be displayed over the measure. */
-  message: string;
 
   /** The duration that the message measure should play for. */
   durationMs: number;
@@ -58,11 +55,20 @@ export type MessageMeasure = {
   /** The width of the messeage measure in pixels. It will be clamped to the width of the score. */
   width: number;
 
+  /** The message to be displayed over the measure. */
+  message?: string;
+
+  /** The barline type at the beginning of the gap. */
+  startBarlineType?: 'single' | 'none';
+
+  /** The barline type at the end of the gap. */
+  endBarlineType?: 'single' | 'none';
+
   /** The stroke style of the message measure rect. */
-  strokeStyle?: string;
+  strokeStyle?: string | null;
 
   /** The fill style of the message measure rect. */
-  fillStyle?: string;
+  fillStyle?: string | null;
 
   /** The font size of the message. */
   fontSize?: string;

--- a/src/vexml.ts
+++ b/src/vexml.ts
@@ -18,7 +18,7 @@ export type RenderOptions = {
 
 /** Vexml contains the core operation of this library: rendering MusicXML in a web browser. */
 export class Vexml {
-  private messageMeasures = new Array<rendering.MessageMeasure>();
+  private gaps = new Array<rendering.Gap>();
 
   private constructor(private musicXML: musicxml.MusicXML) {}
 
@@ -84,11 +84,11 @@ export class Vexml {
   }
 
   /** Sets the message measures for this Vexml instance. */
-  setMessageMeasures(...messageMeasures: rendering.MessageMeasure[]): this {
-    this.messageMeasures = messageMeasures;
+  setGaps(...gaps: rendering.Gap[]): this {
+    this.gaps = gaps;
 
     // We validate the indexes because it is error-prone to insert message measures with incorrect indexes.
-    const indexes = messageMeasures.map(({ absoluteMeasureIndex }) => absoluteMeasureIndex);
+    const indexes = gaps.map(({ absoluteMeasureIndex }) => absoluteMeasureIndex);
     const seen = new Set<number>();
     for (const index of indexes) {
       if (index < 0) {
@@ -134,7 +134,7 @@ export class Vexml {
       config,
       log,
       musicXML: { scorePartwise },
-      messageMeasures: this.messageMeasures,
+      gaps: this.gaps,
     });
     const scoreRendering = score.render({ root, width });
 


### PR DESCRIPTION
I realized that `MessageMeasure` can be generically used for any non-musical pause. I rename it to `Gap` and updated the public interface accordingly.