### PR TITLE
Fix metronome rendering when changing mid-score

### DIFF
--- a/src/rendering/stave.ts
+++ b/src/rendering/stave.ts
@@ -355,7 +355,7 @@ export class Stave {
     const isFirstFragment = this.document.isFirstFragment(this.key);
     const isFirstPart = this.document.isFirstPart(this.key);
     const isFirstStave = this.document.isFirstStave(this.key);
-    const isAbsolutelyFirst = isFirstSystem && isFirstMeasure && isFirstFragment && isFirstPart && isFirstStave;
+    const isAbsolutelyFirst = isFirstSystem && isFirstMeasure && isFirstFragment;
 
     const currentMetronome = this.document.getFragment(this.key).signature.metronome;
     const previousMetronome = this.document.getPreviousFragment(this.key)?.signature.metronome;
@@ -370,7 +370,7 @@ export class Stave {
     const hasMetronome =
       currentMetronome.displayBpm || currentMetronome.dots || currentMetronome.dots2 || currentMetronome.duration;
 
-    if (hasMetronome && (isAbsolutelyFirst || didMetronomeChange)) {
+    if (hasMetronome && isFirstPart && isFirstStave && (isAbsolutelyFirst || didMetronomeChange)) {
       vexflowStave.setTempo({ ...currentMetronome, bpm: currentMetronome.displayBpm }, -METRONOME_TOP_PADDING);
     }
   }


### PR DESCRIPTION
PR #267 didn't fully fix #261 — it only fixed metronomes in the absolute first fragment of the score. This PR fully fixes #261 by requiring **all** rendered metronomes to be in the first part and first stave (not necessarily absolute first).

This fix should be included in ^0.1.3.

Before

<img width="362" alt="image" src="https://github.com/user-attachments/assets/d0b6c42d-f742-40ea-9eca-2bb40de5d35c" />

After

<img width="346" alt="image" src="https://github.com/user-attachments/assets/48928a09-2a02-4f98-89fb-69cdebc2b159" />
