### PR TITLE
Fix playback sequence/cursor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import * as vexml from '@stringsync/vexml';
 const mxl = new Blob(['some', 'valid', 'mxl', 'bytes']);
 const div = document.getElementById('my-id');
 const scorePromise = vexml.renderMXL(musicXML, div);
+// From here, you need to await or call then() on the scorePromise to extract the score.
 ```
 
 ## Advanced Usage

--- a/src/elements/score.ts
+++ b/src/elements/score.ts
@@ -338,7 +338,7 @@ export class Score {
 
   @util.memoize()
   private getSequences(): playback.Sequence[] {
-    const sequences = new playback.SequenceFactory(this).create();
+    const sequences = new playback.SequenceFactory(this.log, this).create();
     return sequences;
   }
 

--- a/src/playback/sequencefactory.ts
+++ b/src/playback/sequencefactory.ts
@@ -109,11 +109,17 @@ export class SequenceFactory {
     }
 
     return events.sort((a, b) => {
-      // When the times match, we want the stop event to come first.
-      if (a.time.ms === b.time.ms) {
+      if (a.time.ms !== b.time.ms) {
+        return a.time.ms - b.time.ms;
+      }
+
+      if (a.type !== b.type) {
+        // Stop events should come before start events.
         return a.type === 'stop' ? -1 : 1;
       }
-      return a.time.ms - b.time.ms;
+
+      // If two events occur at the same time and have the same type, sort by x-coordinate.
+      return a.element.rect().center().x - b.element.rect().center().x;
     });
   }
 

--- a/src/playback/sequencefactory.ts
+++ b/src/playback/sequencefactory.ts
@@ -186,10 +186,21 @@ class SequenceEntryBuilder {
       const instruction = this.getXRangeInstruction(this.anchor, event.element);
 
       if (instruction === 'anchor-to-next-event') {
-        const x1 = this.x;
+        let x1 = this.x;
         const x2 = this.getLeftBoundaryX(event.element);
         const t1 = this.t;
         const t2 = event.time;
+
+        if (x1 > x2) {
+          // See https://github.com/stringsync/vexml/issues/264 for context.
+          this.log.warn('encountered a sequence-building issue where x1 > x2, forcing a fix', {
+            x1,
+            x2,
+            x: this.x,
+            absoluteMeasureIndex: event.element.getAbsoluteMeasureIndex(),
+          });
+          x1 = this.anchor.rect().center().x;
+        }
 
         this.processPending(new NumberRange(x1, x2), t1);
         this.active.push(event.element);

--- a/src/playback/sequencefactory.ts
+++ b/src/playback/sequencefactory.ts
@@ -6,6 +6,7 @@ import { Sequence } from './sequence';
 import { PlaybackElement, SequenceEntry } from './types';
 import { DurationRange } from './durationrange';
 import { MeasureSequenceIterator } from './measuresequenceiterator';
+import { Logger } from '@/debug';
 
 const LAST_SYSTEM_MEASURE_X_RANGE_PADDING_RIGHT = 10;
 
@@ -16,7 +17,7 @@ type SequenceEvent = {
 };
 
 export class SequenceFactory {
-  constructor(private score: elements.Score) {}
+  constructor(private log: Logger, private score: elements.Score) {}
 
   create(): Sequence[] {
     const sequences = new Array<Sequence>();
@@ -125,7 +126,7 @@ export class SequenceFactory {
 
   private toSequenceEntries(events: SequenceEvent[]): SequenceEntry[] {
     const measures = this.score.getMeasures();
-    const builder = new SequenceEntryBuilder(measures);
+    const builder = new SequenceEntryBuilder(this.log, measures);
 
     for (const event of events) {
       builder.add(event);
@@ -152,7 +153,7 @@ class SequenceEntryBuilder {
   private t = Duration.ms(-1);
   private built = false;
 
-  constructor(private measures: elements.Measure[]) {}
+  constructor(private log: Logger, private measures: elements.Measure[]) {}
 
   add(event: SequenceEvent): void {
     if (event.type === 'start') {

--- a/src/playback/sequencefactory.ts
+++ b/src/playback/sequencefactory.ts
@@ -108,7 +108,13 @@ export class SequenceFactory {
       measureStartTime = nextMeasureStartTime;
     }
 
-    return events.sort((a, b) => a.time.ms - b.time.ms);
+    return events.sort((a, b) => {
+      // When the times match, we want the stop event to come first.
+      if (a.time.ms === b.time.ms) {
+        return a.type === 'stop' ? -1 : 1;
+      }
+      return a.time.ms - b.time.ms;
+    });
   }
 
   private toSequenceEntries(events: SequenceEvent[]): SequenceEntry[] {

--- a/src/playback/sequencefactory.ts
+++ b/src/playback/sequencefactory.ts
@@ -261,7 +261,7 @@ class SequenceEntryBuilder {
   ): void {
     const durationRange = new DurationRange(t1, t2);
     const xRange = new NumberRange(x1, x2);
-    this.entries.push({ durationRange, xRange, anchorElement: anchor, activeElements: active });
+    this.entries.push({ durationRange, xRange, anchorElement: anchor, activeElements: [...active] });
   }
 
   private getLeftBoundaryX(element: PlaybackElement): number {


### PR DESCRIPTION
This PR partially fixes #264. It will be included in ^0.1.3

It updates `SequenceFactory` to account for multiple staves in a part. However, it does not cover all edge cases. I created #270 to follow up.