### PR TITLE
Implement cursor spans

### DIFF
--- a/src/elements/score.ts
+++ b/src/elements/score.ts
@@ -65,8 +65,15 @@ export class Score {
   }
 
   addCursor(opts?: { partIndex?: number; span?: playback.CursorVerticalSpan }): playback.Cursor {
+    const partCount = this.getPartCount();
+
     const partIndex = opts?.partIndex ?? 0;
-    const span = opts?.span ?? { fromPartIndex: 0, toPartIndex: this.getPartCount() - 1 };
+    util.assert(0 <= partIndex && partIndex < partCount, 'partIndex out of bounds');
+
+    const span = opts?.span ?? { fromPartIndex: 0, toPartIndex: 0 };
+    util.assert(0 <= span.fromPartIndex && span.fromPartIndex < partCount, 'fromPartIndex out of bounds');
+    util.assert(0 <= span.toPartIndex && span.toPartIndex < partCount, 'toPartIndex out of bounds');
+    util.assert(span.fromPartIndex <= span.toPartIndex, 'fromPartIndex must be less than or equal to toPartIndex');
 
     const sequence = this.getSequences().find((sequence) => sequence.getPartIndex() === partIndex);
     util.assertDefined(sequence);

--- a/src/elements/score.ts
+++ b/src/elements/score.ts
@@ -71,7 +71,7 @@ export class Score {
     const sequence = this.getSequences().find((sequence) => sequence.getPartIndex() === partIndex);
     util.assertDefined(sequence);
 
-    const cursor = playback.Cursor.create(this.root.getScrollContainer(), this, partIndex, sequence, span);
+    const cursor = playback.Cursor.create(this.root.getScrollContainer(), this, sequence, span);
     this.cursors.push(cursor);
     return cursor;
   }

--- a/src/elements/score.ts
+++ b/src/elements/score.ts
@@ -64,15 +64,14 @@ export class Score {
     return this.root.getScrollContainer();
   }
 
-  addCursor(opts?: { partIndex?: number; span?: { fromPartIndex: number; toPartIndex: number } }): playback.Cursor {
+  addCursor(opts?: { partIndex?: number; span?: playback.CursorVerticalSpan }): playback.Cursor {
     const partIndex = opts?.partIndex ?? 0;
-    const span = opts?.span ?? { fromPartIndex: partIndex, toPartIndex: partIndex };
-    util.assert(span.fromPartIndex <= span.toPartIndex, 'fromPartIndex must be less than or equal to toPartIndex');
+    const span = opts?.span ?? { fromPartIndex: 0, toPartIndex: this.getPartCount() - 1 };
 
     const sequence = this.getSequences().find((sequence) => sequence.getPartIndex() === partIndex);
     util.assertDefined(sequence);
 
-    const cursor = playback.Cursor.create(this.root.getScrollContainer(), this, partIndex, sequence);
+    const cursor = playback.Cursor.create(this.root.getScrollContainer(), this, partIndex, sequence, span);
     this.cursors.push(cursor);
     return cursor;
   }

--- a/src/elements/score.ts
+++ b/src/elements/score.ts
@@ -64,10 +64,14 @@ export class Score {
     return this.root.getScrollContainer();
   }
 
-  addCursor(opts?: { partIndex?: number }): playback.Cursor {
+  addCursor(opts?: { partIndex?: number; span?: { fromPartIndex: number; toPartIndex: number } }): playback.Cursor {
     const partIndex = opts?.partIndex ?? 0;
+    const span = opts?.span ?? { fromPartIndex: partIndex, toPartIndex: partIndex };
+    util.assert(span.fromPartIndex <= span.toPartIndex, 'fromPartIndex must be less than or equal to toPartIndex');
+
     const sequence = this.getSequences().find((sequence) => sequence.getPartIndex() === partIndex);
     util.assertDefined(sequence);
+
     const cursor = playback.Cursor.create(this.root.getScrollContainer(), this, partIndex, sequence);
     this.cursors.push(cursor);
     return cursor;

--- a/src/playback/cursor.ts
+++ b/src/playback/cursor.ts
@@ -24,12 +24,18 @@ type EventMap = {
   change: CursorState;
 };
 
+export type CursorVerticalSpan = {
+  fromPartIndex: number;
+  toPartIndex: number;
+};
+
 export class Cursor {
   private scroller: Scroller;
   private states: CursorState[];
   private sequence: playback.Sequence;
   private cheapLocator: CheapLocator;
   private expensiveLocator: ExpensiveLocator;
+  private span: CursorVerticalSpan;
 
   private topic = new events.Topic<EventMap>();
   private index = 0;
@@ -41,20 +47,25 @@ export class Cursor {
     sequence: playback.Sequence;
     cheapLocator: CheapLocator;
     expensiveLocator: ExpensiveLocator;
+    span: CursorVerticalSpan;
   }) {
     this.scroller = opts.scroller;
     this.states = opts.states;
     this.sequence = opts.sequence;
     this.cheapLocator = opts.cheapLocator;
     this.expensiveLocator = opts.expensiveLocator;
+    this.span = opts.span;
   }
 
   static create(
     scrollContainer: HTMLElement,
     score: elements.Score,
     partIndex: number,
-    sequence: playback.Sequence
+    sequence: playback.Sequence,
+    span: CursorVerticalSpan
   ): Cursor {
+    util.assert(span.fromPartIndex <= span.toPartIndex, 'fromPartIndex must be less than or equal to toPartIndex');
+
     // NumberRange objects indexed by system index for the part.
     const systemPartYRanges = new Array<util.NumberRange>();
 
@@ -64,7 +75,7 @@ export class Cursor {
           .getMeasures()
           .flatMap((measure) => measure.getFragments())
           .flatMap((fragment) => fragment.getParts())
-          .filter((part) => part.getIndex() === partIndex)
+          .filter((part) => span.fromPartIndex <= part.getIndex() && part.getIndex() <= span.toPartIndex)
           .map((part) => part.rect())
       );
       const yRange = new util.NumberRange(rect.top(), rect.bottom());
@@ -117,6 +128,7 @@ export class Cursor {
       sequence,
       cheapLocator,
       expensiveLocator,
+      span,
     });
   }
 

--- a/src/playback/cursor.ts
+++ b/src/playback/cursor.ts
@@ -63,8 +63,6 @@ export class Cursor {
     sequence: playback.Sequence,
     span: CursorVerticalSpan
   ): Cursor {
-    util.assert(span.fromPartIndex <= span.toPartIndex, 'fromPartIndex must be less than or equal to toPartIndex');
-
     // NumberRange objects indexed by system index for the part.
     const systemPartYRanges = new Array<util.NumberRange>();
 

--- a/src/playback/cursor.ts
+++ b/src/playback/cursor.ts
@@ -60,7 +60,6 @@ export class Cursor {
   static create(
     scrollContainer: HTMLElement,
     score: elements.Score,
-    partIndex: number,
     sequence: playback.Sequence,
     span: CursorVerticalSpan
   ): Cursor {

--- a/src/playback/types.ts
+++ b/src/playback/types.ts
@@ -2,8 +2,6 @@ import * as elements from '@/elements';
 import { NumberRange } from '@/util';
 import { DurationRange } from './durationrange';
 
-export type CursorVerticalSpan = 'system' | 'part';
-
 export type SequenceEntry = {
   anchorElement: PlaybackElement;
   activeElements: PlaybackElement[];


### PR DESCRIPTION
This PR fixes #264 by adding a mechanism to specify a cursor span. It `span` is `undefined`, it will default to spanning across all parts.

```ts
score.addCursor({ partIndex: 0, span: { fromPartIndex: 0, toPartIndex: 1 });
```

Before

<img width="450" alt="image" src="https://github.com/user-attachments/assets/99b0a4c4-693d-4b74-9c0f-a6f290e14522" />

After 

<img width="464" alt="image" src="https://github.com/user-attachments/assets/27efcd09-cc4c-4179-8023-2aaae49237db" />
